### PR TITLE
In JSON output, for errors make data element a list [4799]

### DIFF
--- a/cli.json
+++ b/cli.json
@@ -5,7 +5,7 @@
   "commands": [
     {
       "name": "edgeworkers",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "aliases": ["ew", "edgeworkers"],
       "description": "Manage Akamai EdgeWorkers code bundles."
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akamai-edgeworkers-cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A tool that makes it easier to manage Akamai EdgeWorkers function bundles. Call the EdgeWorkers API from the command line.",
   "repository": "https://github.com/akamai/cli-edgeworkers",
   "scripts": {

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -496,7 +496,7 @@ async function createNewVersion(ewId: string, options: { bundle?: string, codeDi
           matched_checksum: matchedVersion['checksum']
         }
       }
-      cliUtils.logAndExit(1, `ERROR: Checksum for EdgeWorkers bundle provided matches existing version!`, errorValues);
+      cliUtils.logAndExit(1, `ERROR: Checksum for EdgeWorkers bundle provided matches existing version!`, [errorValues]);
     }
     else {
       //if all remains good, then upload tarball and output checksum and version number

--- a/src/service/edgeworkers-client-manager.ts
+++ b/src/service/edgeworkers-client-manager.ts
@@ -311,7 +311,7 @@ export function writeJSONOutput(exitCode: number, msg: string, data = {}) {
   // Check if msg is already JSON - which would happen if OPEN API response failed for some reason
   if(cliUtils.isJSON(msg)) {
     outputMsg = 'An OPEN API error has occurred!';
-    outputData = JSON.parse(msg);
+    outputData = [JSON.parse(msg)];
   }
   else {
     outputMsg = msg;

--- a/src/utils/cli-utils.ts
+++ b/src/utils/cli-utils.ts
@@ -20,7 +20,7 @@ function log(txt, type = 'log') {
   }
 }
 
-export function logAndExit(exitCode: number, msg: string, data = {}) {
+export function logAndExit(exitCode: number, msg: string, data =[{}]) {
 
   if(edgeWorkersClientSvc.isJSONOutputMode())
     edgeWorkersClientSvc.writeJSONOutput(exitCode, msg, data);


### PR DESCRIPTION
Update to make success and failure JSON payloads similar for the data element.   After this PR both should yield a data element that is a list of arrays, not just a single array as was the case for the failure output.