### PR TITLE
Fix/EW-12123 EdgeKV Revoke Token command displays a wrong message for an error scenario

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "akamai-edgeworkers-cli",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/edgekv/ekv-handler.ts
+++ b/src/edgekv/ekv-handler.ts
@@ -306,7 +306,7 @@ export async function revokeToken(tokenName: string) {
   if (revokedToken != undefined && !revokedToken.isError) {
     cliUtils.logWithBorder(`${tokenName} was successfully revoked and removed from the EdgeKV access token list.`);
   } else {
-    response.logError(revokedToken, `ERROR: Unable to revoke EdgeKV token. A token with the name my_token does not exist. [TraceId: ${revokedToken.traceId}]`)
+    response.logError(revokedToken, `ERROR: Unable to revoke EdgeKV token. ${revokedToken.error_reason} [TraceId: ${revokedToken.traceId}]`)
   }
 }
 


### PR DESCRIPTION
## Major Changes
- Fixed the hardcoded error message in EdgeKV revoke token command

## Test Results
- Test against token does not exist
![image](https://user-images.githubusercontent.com/108763111/178517384-37ea169f-f376-4322-928e-e4546246117c.png)

- Test against account hits revoke limit
![image](https://user-images.githubusercontent.com/108763111/178518225-98bbc839-f262-4cff-9447-5904968a463f.png)
