### PR TITLE
EW-12480 Remove double quotes to string values in EdgeKV CLI 

### DIFF
--- a/cli.json
+++ b/cli.json
@@ -5,13 +5,13 @@
   "commands": [
     {
       "name": "edgeworkers",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "aliases": ["ew", "edgeworkers"],
       "description": "Manage Akamai EdgeWorkers code bundles."
     },
     {
       "name": "edgekv",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "aliases": ["ekv", "edgekv"],
       "description": "Manage Akamai EdgeKV database."
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akamai-edgeworkers-cli",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A tool that makes it easier to manage Akamai EdgeWorkers code bundles and EdgeKV databases. Call the EdgeWorkers and EdgeKV API from the command line.",
   "repository": "https://github.com/akamai/cli-edgeworkers",
   "scripts": {

--- a/src/edgekv/ekv-service.ts
+++ b/src/edgekv/ekv-service.ts
@@ -10,121 +10,335 @@ const INIT_EKV_TIMEOUT = 120000;
 const DEFAULT_EKV_TIMEOUT = 60000;
 
 export function getNameSpaceList(network: string, details: boolean) {
-  var qs: string = "";
+  var qs: string = '';
   if (details) {
-    qs += `?details=${details}`
+    qs += `?details=${details}`;
   }
-  return httpEdge.getJson(`${EDGEKV_API_BASE}/networks/${network}/namespaces${qs}`, cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT), ekvMetrics.listNameSpaces).then(r => r.body).catch(err => error.handleError(err));
+  return httpEdge
+    .getJson(
+      `${EDGEKV_API_BASE}/networks/${network}/namespaces${qs}`,
+      cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT),
+      ekvMetrics.listNameSpaces
+    )
+    .then((r) => r.body)
+    .catch((err) => error.handleError(err));
 }
 
 export function getGroupsList(network: string, namespace: string) {
-  return httpEdge.getJson(`${EDGEKV_API_BASE}/networks/${network}/namespaces/${namespace}/groups`, cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT), ekvMetrics.listGroups).then(r => r.body).catch(err => error.handleError(err));
+  return httpEdge
+    .getJson(
+      `${EDGEKV_API_BASE}/networks/${network}/namespaces/${namespace}/groups`,
+      cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT),
+      ekvMetrics.listGroups
+    )
+    .then((r) => r.body)
+    .catch((err) => error.handleError(err));
 }
 
-export function createNameSpace(network: string, namespace: string, retention, groupId, geoLocation) {
-  var body = { "namespace": namespace, "retentionInSeconds": retention, "groupId": groupId,"geoLocation": geoLocation};
-  return httpEdge.postJson(`${EDGEKV_API_BASE}/networks/${network}/namespaces`, body, cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT), ekvMetrics.createNamespace).then(r => r.body).catch(err => error.handleError(err));
+export function createNameSpace(
+  network: string,
+  namespace: string,
+  retention,
+  groupId,
+  geoLocation
+) {
+  var body = {
+    namespace: namespace,
+    retentionInSeconds: retention,
+    groupId: groupId,
+    geoLocation: geoLocation,
+  };
+  return httpEdge
+    .postJson(
+      `${EDGEKV_API_BASE}/networks/${network}/namespaces`,
+      body,
+      cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT),
+      ekvMetrics.createNamespace
+    )
+    .then((r) => r.body)
+    .catch((err) => error.handleError(err));
 }
 
 export function getNameSpace(network: string, namespace: string) {
-  return httpEdge.getJson(`${EDGEKV_API_BASE}/networks/${network}/namespaces/${namespace}`, cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT), ekvMetrics.showNamespace).then(r => r.body).catch(err => error.handleError(err));
+  return httpEdge
+    .getJson(
+      `${EDGEKV_API_BASE}/networks/${network}/namespaces/${namespace}`,
+      cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT),
+      ekvMetrics.showNamespace
+    )
+    .then((r) => r.body)
+    .catch((err) => error.handleError(err));
 }
 
-export function updateNameSpace(network: string, namespace: string, retention, geoLocation) {
-  var body = { "namespace": namespace, "retentionInSeconds": retention, "geoLocation": geoLocation };
-  return httpEdge.putJson(`${EDGEKV_API_BASE}/networks/${network}/namespaces/${namespace}`, body, cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT), ekvMetrics.updateNamespace).then(r => r.body).catch(err => error.handleError(err));
+export function updateNameSpace(
+  network: string,
+  namespace: string,
+  retention,
+  geoLocation
+) {
+  var body = {
+    namespace: namespace,
+    retentionInSeconds: retention,
+    geoLocation: geoLocation,
+  };
+  return httpEdge
+    .putJson(
+      `${EDGEKV_API_BASE}/networks/${network}/namespaces/${namespace}`,
+      body,
+      cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT),
+      ekvMetrics.updateNamespace
+    )
+    .then((r) => r.body)
+    .catch((err) => error.handleError(err));
 }
 
 export function initializeEdgeKV() {
-  return httpEdge.putJson(`${EDGEKV_API_BASE}/initialize`, "", cliUtils.getTimeout(INIT_EKV_TIMEOUT), ekvMetrics.initialize).then(r => r.response).catch(err => error.handleError(err));
+  return httpEdge
+    .putJson(
+      `${EDGEKV_API_BASE}/initialize`,
+      '',
+      cliUtils.getTimeout(INIT_EKV_TIMEOUT),
+      ekvMetrics.initialize
+    )
+    .then((r) => r.response)
+    .catch((err) => error.handleError(err));
 }
 
 export function getInitializedEdgeKV() {
-  return httpEdge.getJson(`${EDGEKV_API_BASE}/initialize`, cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT), ekvMetrics.showInitStatus).then(r => r.response).catch(err => error.handleError(err));
+  return httpEdge
+    .getJson(
+      `${EDGEKV_API_BASE}/initialize`,
+      cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT),
+      ekvMetrics.showInitStatus
+    )
+    .then((r) => r.response)
+    .catch((err) => error.handleError(err));
 }
 
-export function writeItems(network: string, namespace: string, groupId: string, itemId: string, itemList,sandboxid:string) {
+export function writeItems(
+  network: string,
+  namespace: string,
+  groupId: string,
+  itemId: string,
+  itemList,
+  sandboxid: string
+) {
   let body = itemList;
   let writeItemPath = `${EDGEKV_API_BASE}/networks/${network}/namespaces/${namespace}/groups/${groupId}/items/${itemId}`;
-  if(sandboxid){
-    writeItemPath += `?sandboxId=${sandboxid}`
+  if (sandboxid) {
+    writeItemPath += `?sandboxId=${sandboxid}`;
   }
-  return httpEdge.putJson(writeItemPath, body, cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT), ekvMetrics.writeItem).then(r => r.body).catch(err => error.handleError(err));
+
+  let request: Promise<any>;
+  if (typeof body === 'string') {
+    // If the body is a string
+    request = httpEdge.sendEdgeRequest(
+      writeItemPath,
+      'PUT',
+      body,
+      {
+        'Content-Type': 'text/plain',
+      },
+      cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT),
+      ekvMetrics.writeItem
+    );
+  } else {
+    // If the body is not a string but a JSON object
+    request = httpEdge.putJson(
+      writeItemPath,
+      body,
+      cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT),
+      ekvMetrics.writeItem
+    );
+  }
+
+  return request.then((r) => r.body).catch((err) => error.handleError(err));
 }
 
-export function writeItemsFromFile(network: string, namespace: string, groupId: string, itemId: string, itemPath: string, sandboxid:string) {
+export function writeItemsFromFile(
+  network: string,
+  namespace: string,
+  groupId: string,
+  itemId: string,
+  itemPath: string,
+  sandboxid: string
+) {
   let writeItemFromJsonpath = `${EDGEKV_API_BASE}/networks/${network}/namespaces/${namespace}/groups/${groupId}/items/${itemId}`;
-  if(sandboxid){
-    writeItemFromJsonpath += `?sandboxId=${sandboxid}`
+  if (sandboxid) {
+    writeItemFromJsonpath += `?sandboxId=${sandboxid}`;
   }
-  return httpEdge.sendEdgeRequest(writeItemFromJsonpath, 'PUT', fs.readFileSync(itemPath, { encoding: null}).toString('utf8'), {
-    'Content-Type': 'application/json'
-  }, cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT), ekvMetrics.writeItem).then(r => r.body).catch(err => error.handleError(err));
+  return httpEdge
+    .sendEdgeRequest(
+      writeItemFromJsonpath,
+      'PUT',
+      fs.readFileSync(itemPath, { encoding: null }).toString('utf8'),
+      {
+        'Content-Type': 'application/json',
+      },
+      cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT),
+      ekvMetrics.writeItem
+    )
+    .then((r) => r.body)
+    .catch((err) => error.handleError(err));
 }
 
-export function readItem(network: string, namespace: string, groupId: string, itemId: string,sandboxid:string) {
+export function readItem(
+  network: string,
+  namespace: string,
+  groupId: string,
+  itemId: string,
+  sandboxid: string
+) {
   let readItemPath = `${EDGEKV_API_BASE}/networks/${network}/namespaces/${namespace}/groups/${groupId}/items/${itemId}`;
-  if(sandboxid){
+  if (sandboxid) {
     readItemPath += `?sandboxId=${sandboxid}`;
   }
-  return httpEdge.getJson(readItemPath, cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT),ekvMetrics.readItem).then(r => r.body).catch(err => error.handleError(err));
+  return httpEdge
+    .getJson(
+      readItemPath,
+      cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT),
+      ekvMetrics.readItem
+    )
+    .then((r) => r.body)
+    .catch((err) => error.handleError(err));
 }
 
-export function deleteItem(network: string, namespace: string, groupId: string, itemId: string,sandboxid:string) {
+export function deleteItem(
+  network: string,
+  namespace: string,
+  groupId: string,
+  itemId: string,
+  sandboxid: string
+) {
   let deleteItemPath = `${EDGEKV_API_BASE}/networks/${network}/namespaces/${namespace}/groups/${groupId}/items/${itemId}`;
-  if(sandboxid){
+  if (sandboxid) {
     deleteItemPath += `?sandboxId=${sandboxid}`;
   }
-  return httpEdge.deleteReq(deleteItemPath, cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT),ekvMetrics.deleteItem).then(r => r.body).catch(err => error.handleError(err));
+  return httpEdge
+    .deleteReq(
+      deleteItemPath,
+      cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT),
+      ekvMetrics.deleteItem
+    )
+    .then((r) => r.body)
+    .catch((err) => error.handleError(err));
 }
 
-export function getItemsFromGroup(network: string, namespace: string, groupId: string, maxItems: number, sandboxid:string) {
-  var qs: string = "";
+export function getItemsFromGroup(
+  network: string,
+  namespace: string,
+  groupId: string,
+  maxItems?: number,
+  sandboxid?: string
+) {
+  var qs: string = '';
   if (maxItems !== undefined) {
     qs += `?maxItems=${maxItems}`;
   }
   if (sandboxid) {
-    qs += (maxItems == undefined) ? "?" : "&";
+    qs += maxItems == undefined ? '?' : '&';
     qs += `sandboxId=${sandboxid}`;
   }
 
   let listItemsPath = `${EDGEKV_API_BASE}/networks/${network}/namespaces/${namespace}/groups/${groupId}${qs}`;
-  return httpEdge.getJson(listItemsPath, cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT),ekvMetrics.readItemsFromGroup).then(r => r.body).catch(err => error.handleError(err));
+  return httpEdge
+    .getJson(
+      listItemsPath,
+      cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT),
+      ekvMetrics.readItemsFromGroup
+    )
+    .then((r) => r.body)
+    .catch((err) => error.handleError(err));
 }
 
-export function createEdgeKVToken(tokenName: string, permissionList, allowOnStg: boolean, allowOnProd: boolean, ewids:string[], expiry) {
-
+export function createEdgeKVToken(
+  tokenName: string,
+  permissionList,
+  allowOnStg: boolean,
+  allowOnProd: boolean,
+  ewids: string[],
+  expiry
+) {
   let body = {
-    "name": tokenName, "allowOnProduction": allowOnProd, "allowOnStaging": allowOnStg, "restrictToEwids": ewids ,"expiry": expiry, "namespacePermissions": permissionList
+    name: tokenName,
+    allowOnProduction: allowOnProd,
+    allowOnStaging: allowOnStg,
+    restrictToEwids: ewids,
+    expiry: expiry,
+    namespacePermissions: permissionList,
   };
-  return httpEdge.postJson(`${EDGEKV_API_BASE}/tokens`, body, cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT), ekvMetrics.createToken).then(r => r.body).catch(err => error.handleError(err));
+  return httpEdge
+    .postJson(
+      `${EDGEKV_API_BASE}/tokens`,
+      body,
+      cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT),
+      ekvMetrics.createToken
+    )
+    .then((r) => r.body)
+    .catch((err) => error.handleError(err));
 }
 
 export function getSingleToken(tokenName: string) {
-  return httpEdge.getJson(`${EDGEKV_API_BASE}/tokens/${tokenName}`, cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT), ekvMetrics.readToken).then(r => r.body).catch(err => error.handleError(err));
+  return httpEdge
+    .getJson(
+      `${EDGEKV_API_BASE}/tokens/${tokenName}`,
+      cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT),
+      ekvMetrics.readToken
+    )
+    .then((r) => r.body)
+    .catch((err) => error.handleError(err));
 }
 
 export function getTokenList(incExpired: boolean) {
-  var qs: string = "";
+  var qs: string = '';
   if (incExpired) {
-    qs += `?includeExpired=${incExpired}`
+    qs += `?includeExpired=${incExpired}`;
   }
-  return httpEdge.getJson(`${EDGEKV_API_BASE}/tokens${qs}`, cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT), ekvMetrics.readTokenList).then(r => r.body).catch(err => error.handleError(err));
+  return httpEdge
+    .getJson(
+      `${EDGEKV_API_BASE}/tokens${qs}`,
+      cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT),
+      ekvMetrics.readTokenList
+    )
+    .then((r) => r.body)
+    .catch((err) => error.handleError(err));
 }
 
 export function revokeToken(tokenName: string) {
-  return httpEdge.deleteReq(`${EDGEKV_API_BASE}/tokens/${tokenName}`, cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT), ekvMetrics.deleteToken).then(r => r.body).catch(err => error.handleError(err));
+  return httpEdge
+    .deleteReq(
+      `${EDGEKV_API_BASE}/tokens/${tokenName}`,
+      cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT),
+      ekvMetrics.deleteToken
+    )
+    .then((r) => r.body)
+    .catch((err) => error.handleError(err));
 }
 
 export function modifyAuthGroupPermission(namespace: string, groupId: number) {
-  let body = { "groupId": groupId };
-  return httpEdge.putJson(`${EDGEKV_API_BASE}/auth/namespaces/${namespace}`, body, cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT), ekvMetrics.modifyAuthGroup).then(r => r.body).catch(err => error.handleError(err));
+  let body = { groupId: groupId };
+  return httpEdge
+    .putJson(
+      `${EDGEKV_API_BASE}/auth/namespaces/${namespace}`,
+      body,
+      cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT),
+      ekvMetrics.modifyAuthGroup
+    )
+    .then((r) => r.body)
+    .catch((err) => error.handleError(err));
 }
 
-export function listAuthGroups(groupId: number) {
-  var group: string = "";
-  if (groupId) {
+export function listAuthGroups(groupId?: number) {
+  var group: string = '';
+  if (groupId && groupId > 0) {
     group = `/${groupId}`;
   }
-  return httpEdge.getJson(`${EDGEKV_API_BASE}/auth/groups${group}`, cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT), ekvMetrics.listAuthGroup).then(r => r.body).catch(err => error.handleError(err));
+  return httpEdge
+    .getJson(
+      `${EDGEKV_API_BASE}/auth/groups${group}`,
+      cliUtils.getTimeout(DEFAULT_EKV_TIMEOUT),
+      ekvMetrics.listAuthGroup
+    )
+    .then((r) => r.body)
+    .catch((err) => error.handleError(err));
 }

--- a/tests/edgekv/ekv-services.test.ts
+++ b/tests/edgekv/ekv-services.test.ts
@@ -1,0 +1,1421 @@
+import * as httpEdge from '../../src/cli-httpRequest';
+import * as ekvService from '../../src/edgekv/ekv-service';
+import { ekvMetrics } from '../../src/edgekv/ekv-metricFactory';
+
+describe('ekv-services tests', () => {
+  // Test variables
+  const initTimeout = 120000;
+  const defaultTimeout = 60000;
+  const mockNetwork = 'mockNetwork';
+  const mockNamespace = 'mockNamespace';
+  const mockGroupId = 'mockGroupId';
+  const mockAuthGroupId = 123;
+  const mockItemId = 'mockItemId';
+  const mockSandboxId = 'mockSandboxId';
+  const mockError = {
+    status: 400,
+    detail: 'no permission to access',
+    traceId: 123456,
+  };
+  const mockTokenName = 'mockTokenName';
+  const mockPermissionList = ['abc', 'efg', 'hij'];
+  const mockEwids = ['123', '456', '789'];
+  const mockExpiry = 3600;
+
+  describe('testing getNameSpaceList', () => {
+    const mockResBody = ['space1', 'space2', 'space3'];
+
+    test('URL path should not include query parameter when details parameter is false', async () => {
+      const details = false;
+
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation((path, timeout, metricType) => {
+        expect(path).not.toContain('?details');
+        expect(path).toContain(
+          `${ekvService.EDGEKV_API_BASE}/networks/${mockNetwork}/namespaces`
+        );
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.listNameSpaces);
+
+        return Promise.resolve({
+          body: mockResBody,
+        });
+      });
+
+      const nsListSpy = jest.spyOn(ekvService, 'getNameSpaceList');
+      const res = await ekvService.getNameSpaceList(mockNetwork, details);
+
+      expect(nsListSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResBody);
+    });
+
+    test('URL path should contian query parameter when details parameter is true', async () => {
+      const details = true;
+
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation((path, timeout, metricType) => {
+        expect(path).toContain('?details');
+        expect(path).toContain(
+          `${ekvService.EDGEKV_API_BASE}/networks/${mockNetwork}/namespaces`
+        );
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.listNameSpaces);
+
+        return Promise.resolve({
+          body: mockResBody,
+        });
+      });
+
+      const nsListSpy = jest.spyOn(ekvService, 'getNameSpaceList');
+      const res = await ekvService.getNameSpaceList(mockNetwork, details);
+
+      expect(nsListSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResBody);
+    });
+
+    test('function should handle errors properly', async () => {
+      const details = true;
+
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation(() => {
+        // The normal error object will be returned as a string
+        return Promise.reject(JSON.stringify(mockError));
+      });
+
+      const nsListSpy = jest.spyOn(ekvService, 'getNameSpaceList');
+      const error = await ekvService.getNameSpaceList(mockNetwork, details);
+
+      expect(nsListSpy).toHaveBeenCalled();
+      // Check the details of error object
+      expect(error).not.toBeUndefined;
+      expect(error.isError).toEqual(true);
+      expect(error.status).toEqual(mockError.status);
+      expect(error.error_reason).toEqual(mockError.detail);
+      expect(error.traceId).toEqual(mockError.traceId);
+    });
+  });
+
+  describe('testing getGroupsList', () => {
+    const mockResBody = ['group1', 'group2', 'group3'];
+
+    test('response should return groups list', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation((path, timeout, metricType) => {
+        expect(path).toContain(
+          `${ekvService.EDGEKV_API_BASE}/networks/${mockNetwork}/namespaces/${mockNamespace}/groups`
+        );
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.listGroups);
+
+        return Promise.resolve({
+          body: mockResBody,
+        });
+      });
+
+      const groupsListSpy = jest.spyOn(ekvService, 'getGroupsList');
+      const res = await ekvService.getGroupsList(mockNetwork, mockNamespace);
+
+      expect(groupsListSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResBody);
+    });
+
+    test('function should handle errors properly', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation(() => {
+        // The normal error object will be returned as a string
+        return Promise.reject(JSON.stringify(mockError));
+      });
+
+      const groupsListSpy = jest.spyOn(ekvService, 'getGroupsList');
+      const error = await ekvService.getGroupsList(mockNetwork, mockNamespace);
+
+      expect(groupsListSpy).toHaveBeenCalled();
+      // Check the details of error object
+      expect(error).not.toBeUndefined;
+      expect(error.isError).toEqual(true);
+      expect(error.status).toEqual(mockError.status);
+      expect(error.error_reason).toEqual(mockError.detail);
+      expect(error.traceId).toEqual(mockError.traceId);
+    });
+  });
+
+  describe('testing createNameSpace', () => {
+    const retention = 1000;
+    const groupId = 'mockGroup';
+    const geoLocation = 'mocklocation';
+    const mockReqBody = {
+      namespace: mockNamespace,
+      retentionInSeconds: retention,
+      groupId: groupId,
+      geoLocation: geoLocation,
+    };
+    const mockResBody = { mesaage: 'success' };
+
+    test('response should return created namespace', async () => {
+      // Mock postJson() method
+      const postJsonSpy = jest.spyOn(httpEdge, 'postJson');
+      postJsonSpy.mockImplementation((path, body, timeout, metricType) => {
+        expect(path).toContain(
+          `${ekvService.EDGEKV_API_BASE}/networks/${mockNetwork}/namespaces`
+        );
+        expect(body).toEqual(mockReqBody);
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.createNamespace);
+
+        return Promise.resolve({
+          body: mockResBody,
+        });
+      });
+
+      const createNsSpy = jest.spyOn(ekvService, 'createNameSpace');
+      const res = await ekvService.createNameSpace(
+        mockNetwork,
+        mockNamespace,
+        retention,
+        groupId,
+        geoLocation
+      );
+
+      expect(createNsSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResBody);
+    });
+
+    test('function should handle errors properly', async () => {
+      // Mock postJson() method
+      const postJsonSpy = jest.spyOn(httpEdge, 'postJson');
+      postJsonSpy.mockImplementation(() => {
+        // The normal error object will be returned as a string
+        return Promise.reject(JSON.stringify(mockError));
+      });
+
+      const createNsSpy = jest.spyOn(ekvService, 'createNameSpace');
+      const error = await ekvService.createNameSpace(
+        mockNetwork,
+        mockNamespace,
+        retention,
+        groupId,
+        geoLocation
+      );
+
+      expect(createNsSpy).toHaveBeenCalled();
+      // Check the details of error object
+      expect(error).not.toBeUndefined;
+      expect(error.isError).toEqual(true);
+      expect(error.status).toEqual(mockError.status);
+      expect(error.error_reason).toEqual(mockError.detail);
+      expect(error.traceId).toEqual(mockError.traceId);
+    });
+  });
+
+  describe('testing getNameSpace', () => {
+    const mockResBody = { message: 'success' };
+
+    test('response should return namespace info', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation((path, timeout, metricType) => {
+        expect(path).toContain(
+          `${ekvService.EDGEKV_API_BASE}/networks/${mockNetwork}/namespaces/${mockNamespace}`
+        );
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.showNamespace);
+
+        return Promise.resolve({
+          body: mockResBody,
+        });
+      });
+
+      const getNsSpy = jest.spyOn(ekvService, 'getNameSpace');
+      const res = await ekvService.getNameSpace(mockNetwork, mockNamespace);
+
+      expect(getNsSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResBody);
+    });
+
+    test('function should handle errors properly', async () => {
+      // Mock getJson() method
+
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation(() => {
+        // The normal error object will be returned as a string
+        return Promise.reject(JSON.stringify(mockError));
+      });
+
+      const getNsSpy = jest.spyOn(ekvService, 'getNameSpace');
+      const error = await ekvService.getNameSpace(mockNetwork, mockNamespace);
+
+      expect(getNsSpy).toHaveBeenCalled();
+      // Check the details of error object
+      expect(error).not.toBeUndefined;
+      expect(error.isError).toEqual(true);
+      expect(error.status).toEqual(mockError.status);
+      expect(error.error_reason).toEqual(mockError.detail);
+      expect(error.traceId).toEqual(mockError.traceId);
+    });
+  });
+
+  describe('testing updateNameSpace', () => {
+    const retention = 1000;
+    const geoLocation = 'mockLocation';
+    const mockReqBody = {
+      namespace: mockNamespace,
+      retentionInSeconds: retention,
+      geoLocation: geoLocation,
+    };
+    const mockResBody = { message: 'success' };
+
+    test('response should return changed namespace info', async () => {
+      // Mock putJson() method
+      const putJsonSpy = jest.spyOn(httpEdge, 'putJson');
+      putJsonSpy.mockImplementation((path, body, timeout, metricType) => {
+        expect(path).toContain(
+          `${ekvService.EDGEKV_API_BASE}/networks/${mockNetwork}/namespaces/${mockNamespace}`
+        );
+        expect(body).toEqual(mockReqBody);
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.updateNamespace);
+
+        return Promise.resolve({
+          body: mockResBody,
+        });
+      });
+
+      const updateNsSpy = jest.spyOn(ekvService, 'updateNameSpace');
+      const res = await ekvService.updateNameSpace(
+        mockNetwork,
+        mockNamespace,
+        retention,
+        geoLocation
+      );
+
+      expect(updateNsSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResBody);
+    });
+
+    test('function should handle errors properly', async () => {
+      // Mock putJson() method
+      const putJsonSpy = jest.spyOn(httpEdge, 'putJson');
+      putJsonSpy.mockImplementation(() => {
+        // The normal error object will be returned as a string
+        return Promise.reject(JSON.stringify(mockError));
+      });
+
+      const updateNsSpy = jest.spyOn(ekvService, 'updateNameSpace');
+      const error = await ekvService.updateNameSpace(
+        mockNetwork,
+        mockNamespace,
+        retention,
+        geoLocation
+      );
+
+      expect(updateNsSpy).toHaveBeenCalled();
+      // Check the details of error object
+      expect(error).not.toBeUndefined;
+      expect(error.isError).toEqual(true);
+      expect(error.status).toEqual(mockError.status);
+      expect(error.error_reason).toEqual(mockError.detail);
+      expect(error.traceId).toEqual(mockError.traceId);
+    });
+  });
+
+  describe('testing initializeEdgeKV', () => {
+    const mockReqBody = '';
+    const mockResponse = {
+      statusCode: 200,
+      body: 'success',
+    };
+
+    test('response should return initialization success', async () => {
+      // Mock putJson() method
+      const putJsonSpy = jest.spyOn(httpEdge, 'putJson');
+      putJsonSpy.mockImplementation((path, body, timeout, metricType) => {
+        expect(path).toContain(`${ekvService.EDGEKV_API_BASE}/initialize`);
+        expect(body).toEqual(mockReqBody);
+        expect(timeout).toEqual(initTimeout);
+        expect(metricType).toEqual(ekvMetrics.initialize);
+
+        return Promise.resolve({
+          response: mockResponse,
+        });
+      });
+
+      const initializeSpy = jest.spyOn(ekvService, 'initializeEdgeKV');
+      const res = await ekvService.initializeEdgeKV();
+
+      expect(initializeSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('function should handle errors properly', async () => {
+      // Mock putJson() method
+      const putJsonSpy = jest.spyOn(httpEdge, 'putJson');
+      putJsonSpy.mockImplementation(() => {
+        // The normal error object will be returned as a string
+        return Promise.reject(JSON.stringify(mockError));
+      });
+
+      const initializeSpy = jest.spyOn(ekvService, 'initializeEdgeKV');
+      const error = await ekvService.initializeEdgeKV();
+
+      expect(initializeSpy).toHaveBeenCalled();
+      // Check the details of error object
+      expect(error).not.toBeUndefined;
+      expect(error.isError).toEqual(true);
+      expect(error.status).toEqual(mockError.status);
+      expect(error.error_reason).toEqual(mockError.detail);
+      expect(error.traceId).toEqual(mockError.traceId);
+    });
+  });
+
+  describe('testing getInitializeEdgeKV', () => {
+    const mockResponse = {
+      statusCode: 200,
+      body: 'success',
+    };
+
+    test('response should return initialization success', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation((path, timeout, metricType) => {
+        expect(path).toContain(`${ekvService.EDGEKV_API_BASE}/initialize`);
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.showInitStatus);
+
+        return Promise.resolve({
+          response: mockResponse,
+        });
+      });
+
+      const initializeSpy = jest.spyOn(ekvService, 'getInitializedEdgeKV');
+      const res = await ekvService.getInitializedEdgeKV();
+
+      expect(initializeSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('function should handle errors properly', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation(() => {
+        // The normal error object will be returned as a string
+        return Promise.reject(JSON.stringify(mockError));
+      });
+
+      const initializeSpy = jest.spyOn(ekvService, 'getInitializedEdgeKV');
+      const error = await ekvService.getInitializedEdgeKV();
+
+      expect(initializeSpy).toHaveBeenCalled();
+      // Check the details of error object
+      expect(error).not.toBeUndefined;
+      expect(error.isError).toEqual(true);
+      expect(error.status).toEqual(mockError.status);
+      expect(error.error_reason).toEqual(mockError.detail);
+      expect(error.traceId).toEqual(mockError.traceId);
+    });
+  });
+
+  describe('testing wrtieItems', () => {
+    const textItem = 'mockItem';
+    const jsonItems = {
+      item1: 'item1',
+      item2: 'item2',
+      item3: 'item3',
+    };
+    const expectedHeaders = {
+      'Content-Type': 'text/plain',
+    };
+    const mockResponse = {
+      statusCode: 201,
+      body: 'upsert success',
+    };
+
+    test('URL path should not contain sandboxId if the query parameter is not provided', async () => {
+      // Mock sendEdgeRequest() method
+      const sendEdgeRequestSpy = jest.spyOn(httpEdge, 'sendEdgeRequest');
+      sendEdgeRequestSpy.mockImplementation(
+        (path, method, body, headers, timeout, metricType) => {
+          expect(path).not.toContain('?sandboxId=');
+          expect(path).toContain(
+            `${ekvService.EDGEKV_API_BASE}/networks/${mockNetwork}/namespaces/${mockNamespace}/groups/${mockGroupId}/items/${mockItemId}`
+          );
+          expect(method).toEqual('PUT');
+          expect(body).toEqual(textItem);
+          expect(headers).toEqual(expectedHeaders);
+          expect(timeout).toEqual(defaultTimeout);
+          expect(metricType).toEqual(ekvMetrics.writeItem);
+
+          return Promise.resolve({
+            body: mockResponse,
+          });
+        }
+      );
+
+      const writeItemsSpy = jest.spyOn(ekvService, 'writeItems');
+      const res = await ekvService.writeItems(
+        mockNetwork,
+        mockNamespace,
+        mockGroupId,
+        mockItemId,
+        textItem,
+        ''
+      );
+
+      expect(writeItemsSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('URL path should contain sandboxId if the query parameter is provided', async () => {
+      // Mock sendEdgeRequest() method
+      const sendEdgeRequestSpy = jest.spyOn(httpEdge, 'sendEdgeRequest');
+      sendEdgeRequestSpy.mockImplementation(
+        (path, method, body, headers, timeout, metricType) => {
+          expect(path).toContain(`?sandboxId=${mockSandboxId}`);
+          expect(path).toContain(
+            `${ekvService.EDGEKV_API_BASE}/networks/${mockNetwork}/namespaces/${mockNamespace}/groups/${mockGroupId}/items/${mockItemId}`
+          );
+          expect(method).toEqual('PUT');
+          expect(body).toEqual(textItem);
+          expect(headers).toEqual(expectedHeaders);
+          expect(timeout).toEqual(defaultTimeout);
+          expect(metricType).toEqual(ekvMetrics.writeItem);
+
+          return Promise.resolve({
+            body: mockResponse,
+          });
+        }
+      );
+
+      const writeItemsSpy = jest.spyOn(ekvService, 'writeItems');
+      const res = await ekvService.writeItems(
+        mockNetwork,
+        mockNamespace,
+        mockGroupId,
+        mockItemId,
+        textItem,
+        mockSandboxId
+      );
+
+      expect(writeItemsSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('response should return writeItems success when body is a JSON object string', async () => {
+      // Mock putJson() method
+      const putJson = jest.spyOn(httpEdge, 'putJson');
+      putJson.mockImplementation((path, body, timeout, metricType) => {
+        expect(path).not.toContain(`?sandboxId=${mockSandboxId}`);
+        expect(path).toContain(
+          `${ekvService.EDGEKV_API_BASE}/networks/${mockNetwork}/namespaces/${mockNamespace}/groups/${mockGroupId}/items/${mockItemId}`
+        );
+        expect(body).toEqual(jsonItems);
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.writeItem);
+
+        return Promise.resolve({
+          body: mockResponse,
+        });
+      });
+
+      const writeItemsSpy = jest.spyOn(ekvService, 'writeItems');
+      const res = await ekvService.writeItems(
+        mockNetwork,
+        mockNamespace,
+        mockGroupId,
+        mockItemId,
+        jsonItems,
+        ''
+      );
+
+      expect(writeItemsSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('function should handle errors properly', async () => {
+      // Mock sendEdgeRequest() method
+      const sendEdgeRequestSpy = jest.spyOn(httpEdge, 'sendEdgeRequest');
+      sendEdgeRequestSpy.mockImplementation(() => {
+        // The normal error object will be returned as a string
+        return Promise.reject(JSON.stringify(mockError));
+      });
+
+      const writeItemsSpy = jest.spyOn(ekvService, 'writeItems');
+      const error = await ekvService.writeItems(
+        mockNetwork,
+        mockNamespace,
+        mockGroupId,
+        mockItemId,
+        textItem,
+        ''
+      );
+
+      expect(writeItemsSpy).toHaveBeenCalled();
+      // Check the details of error object
+      expect(error).not.toBeUndefined;
+      expect(error.isError).toEqual(true);
+      expect(error.status).toEqual(mockError.status);
+      expect(error.error_reason).toEqual(mockError.detail);
+      expect(error.traceId).toEqual(mockError.traceId);
+    });
+  });
+
+  describe('testing wrtieItemsFromFile', () => {
+    const itemFilePath = __dirname + '/items.json';
+    const jsonItems = JSON.stringify({
+      item1: 'item1',
+      item2: 'item2',
+      item3: 'item3',
+    });
+    const expectedHeaders = {
+      'Content-Type': 'application/json',
+    };
+    const mockResponse = {
+      statusCode: 201,
+      body: 'upsert success',
+    };
+
+    test('URL path should not contain sandboxId if the query parameter is not provided', async () => {
+      // Mock sendEdgeRequest() method
+      const sendEdgeRequestSpy = jest.spyOn(httpEdge, 'sendEdgeRequest');
+      sendEdgeRequestSpy.mockImplementation(
+        (path, method, body, headers, timeout, metricType) => {
+          expect(path).not.toContain('?sandboxId=');
+          expect(path).toContain(
+            `${ekvService.EDGEKV_API_BASE}/networks/${mockNetwork}/namespaces/${mockNamespace}/groups/${mockGroupId}/items/${mockItemId}`
+          );
+          expect(method).toEqual('PUT');
+          expect(JSON.stringify(JSON.parse(body))).toEqual(jsonItems);
+          expect(headers).toEqual(expectedHeaders);
+          expect(timeout).toEqual(defaultTimeout);
+          expect(metricType).toEqual(ekvMetrics.writeItem);
+
+          return Promise.resolve({
+            body: mockResponse,
+          });
+        }
+      );
+
+      const writeItemsFromFileSpy = jest.spyOn(
+        ekvService,
+        'writeItemsFromFile'
+      );
+      const res = await ekvService.writeItemsFromFile(
+        mockNetwork,
+        mockNamespace,
+        mockGroupId,
+        mockItemId,
+        itemFilePath,
+        ''
+      );
+
+      expect(writeItemsFromFileSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('URL path should contain sandboxId if the query parameter is provided', async () => {
+      // Mock sendEdgeRequest() method
+      const sendEdgeRequestSpy = jest.spyOn(httpEdge, 'sendEdgeRequest');
+      sendEdgeRequestSpy.mockImplementation(
+        (path, method, body, headers, timeout, metricType) => {
+          expect(path).toContain(`?sandboxId=${mockSandboxId}`);
+          expect(path).toContain(
+            `${ekvService.EDGEKV_API_BASE}/networks/${mockNetwork}/namespaces/${mockNamespace}/groups/${mockGroupId}/items/${mockItemId}`
+          );
+          expect(method).toEqual('PUT');
+          expect(JSON.stringify(JSON.parse(body))).toEqual(jsonItems);
+          expect(headers).toEqual(expectedHeaders);
+          expect(timeout).toEqual(defaultTimeout);
+          expect(metricType).toEqual(ekvMetrics.writeItem);
+
+          return Promise.resolve({
+            body: mockResponse,
+          });
+        }
+      );
+
+      const writeItemsFromFileSpy = jest.spyOn(
+        ekvService,
+        'writeItemsFromFile'
+      );
+      const res = await ekvService.writeItemsFromFile(
+        mockNetwork,
+        mockNamespace,
+        mockGroupId,
+        mockItemId,
+        itemFilePath,
+        mockSandboxId
+      );
+
+      expect(writeItemsFromFileSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('function should handle errors properly', async () => {
+      // Mock sendEdgeRequest() method
+      const sendEdgeRequestSpy = jest.spyOn(httpEdge, 'sendEdgeRequest');
+      sendEdgeRequestSpy.mockImplementation(() => {
+        // The normal error object will be returned as a string
+        return Promise.reject(JSON.stringify(mockError));
+      });
+
+      const writeItemsFromFileSpy = jest.spyOn(
+        ekvService,
+        'writeItemsFromFile'
+      );
+      const error = await ekvService.writeItemsFromFile(
+        mockNetwork,
+        mockNamespace,
+        mockGroupId,
+        mockItemId,
+        itemFilePath,
+        ''
+      );
+
+      expect(writeItemsFromFileSpy).toHaveBeenCalled();
+      // Check the details of error object
+      expect(error).not.toBeUndefined;
+      expect(error.isError).toEqual(true);
+      expect(error.status).toEqual(mockError.status);
+      expect(error.error_reason).toEqual(mockError.detail);
+      expect(error.traceId).toEqual(mockError.traceId);
+    });
+  });
+
+  describe('testing readItem', () => {
+    const mockResponse = {
+      item1: 'item1',
+      item2: 'item2',
+      item3: 'item3',
+    };
+
+    test('URL path should not contain sandboxId if the query parameter is not provided', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation((path, timeout, metricType) => {
+        expect(path).not.toContain('?sandboxId=');
+        expect(path).toContain(
+          `${ekvService.EDGEKV_API_BASE}/networks/${mockNetwork}/namespaces/${mockNamespace}/groups/${mockGroupId}/items/${mockItemId}`
+        );
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.readItem);
+
+        return Promise.resolve({
+          body: mockResponse,
+        });
+      });
+
+      const readitemSpy = jest.spyOn(ekvService, 'readItem');
+      const res = await ekvService.readItem(
+        mockNetwork,
+        mockNamespace,
+        mockGroupId,
+        mockItemId,
+        ''
+      );
+
+      expect(readitemSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('URL path should contain sandboxId if the query parameter is provided', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation((path, timeout, metricType) => {
+        expect(path).toContain('?sandboxId=');
+        expect(path).toContain(
+          `${ekvService.EDGEKV_API_BASE}/networks/${mockNetwork}/namespaces/${mockNamespace}/groups/${mockGroupId}/items/${mockItemId}`
+        );
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.readItem);
+
+        return Promise.resolve({
+          body: mockResponse,
+        });
+      });
+
+      const readItemSpy = jest.spyOn(ekvService, 'readItem');
+      const res = await ekvService.readItem(
+        mockNetwork,
+        mockNamespace,
+        mockGroupId,
+        mockItemId,
+        mockSandboxId
+      );
+
+      expect(readItemSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('function should handle errors properly', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation(() => {
+        // The normal error object will be returned as a string
+        return Promise.reject(JSON.stringify(mockError));
+      });
+
+      const readItemSpy = jest.spyOn(ekvService, 'readItem');
+      const error = await ekvService.readItem(
+        mockNetwork,
+        mockNamespace,
+        mockGroupId,
+        mockItemId,
+        ''
+      );
+
+      expect(readItemSpy).toHaveBeenCalled();
+      // Check the details of error object
+      expect(error).not.toBeUndefined;
+      expect(error.isError).toEqual(true);
+      expect(error.status).toEqual(mockError.status);
+      expect(error.error_reason).toEqual(mockError.detail);
+      expect(error.traceId).toEqual(mockError.traceId);
+    });
+  });
+
+  describe('testing deleteItem', () => {
+    const mockResponse = {
+      statusCode: 204,
+    };
+
+    test('URL path should not contain sandboxId if the query parameter is not provided', async () => {
+      // Mock deleteReq() method
+      const deleteReqSpy = jest.spyOn(httpEdge, 'deleteReq');
+      deleteReqSpy.mockImplementation((path, timeout, metricType) => {
+        expect(path).not.toContain('?sandboxId=');
+        expect(path).toContain(
+          `${ekvService.EDGEKV_API_BASE}/networks/${mockNetwork}/namespaces/${mockNamespace}/groups/${mockGroupId}/items/${mockItemId}`
+        );
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.deleteItem);
+
+        return Promise.resolve({
+          body: mockResponse,
+        });
+      });
+
+      const deleteItemSpy = jest.spyOn(ekvService, 'deleteItem');
+      const res = await ekvService.deleteItem(
+        mockNetwork,
+        mockNamespace,
+        mockGroupId,
+        mockItemId,
+        ''
+      );
+
+      expect(deleteItemSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('URL path should contain sandboxId if the query parameter is provided', async () => {
+      // Mock deleteReq() method
+      const deleteReqSpy = jest.spyOn(httpEdge, 'deleteReq');
+      deleteReqSpy.mockImplementation((path, timeout, metricType) => {
+        expect(path).toContain('?sandboxId=');
+        expect(path).toContain(
+          `${ekvService.EDGEKV_API_BASE}/networks/${mockNetwork}/namespaces/${mockNamespace}/groups/${mockGroupId}/items/${mockItemId}`
+        );
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.deleteItem);
+
+        return Promise.resolve({
+          body: mockResponse,
+        });
+      });
+
+      const deleteItemSpy = jest.spyOn(ekvService, 'deleteItem');
+      const res = await ekvService.deleteItem(
+        mockNetwork,
+        mockNamespace,
+        mockGroupId,
+        mockItemId,
+        mockSandboxId
+      );
+
+      expect(deleteItemSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('function should handle errors properly', async () => {
+      // Mock deleteReq() method
+      const deleteReqSpy = jest.spyOn(httpEdge, 'deleteReq');
+      deleteReqSpy.mockImplementation((path, timeout, metricType) => {
+        // The normal error object will be returned as a string
+        return Promise.reject(JSON.stringify(mockError));
+      });
+
+      const deleteItemSpy = jest.spyOn(ekvService, 'deleteItem');
+      const error = await ekvService.deleteItem(
+        mockNetwork,
+        mockNamespace,
+        mockGroupId,
+        mockItemId,
+        ''
+      );
+
+      expect(deleteItemSpy).toHaveBeenCalled();
+      // Check the details of error object
+      expect(error).not.toBeUndefined;
+      expect(error.isError).toEqual(true);
+      expect(error.status).toEqual(mockError.status);
+      expect(error.error_reason).toEqual(mockError.detail);
+      expect(error.traceId).toEqual(mockError.traceId);
+    });
+  });
+
+  describe('testing getItemsFromGroup', () => {
+    const maxItems = 3;
+    const mockResponse = {
+      item1: 'item1',
+      item2: 'item2',
+      item3: 'item3',
+    };
+
+    test('URL path should not contain maxItems if the query parameter is not provided', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation((path, timeout, metricType) => {
+        expect(path).not.toContain('?maxItems=');
+        expect(path).toContain(
+          `${ekvService.EDGEKV_API_BASE}/networks/${mockNetwork}/namespaces/${mockNamespace}/groups/${mockGroupId}`
+        );
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.readItemsFromGroup);
+
+        return Promise.resolve({
+          body: mockResponse,
+        });
+      });
+
+      const getItemsFromGroupSpy = jest.spyOn(ekvService, 'getItemsFromGroup');
+      const res = await ekvService.getItemsFromGroup(
+        mockNetwork,
+        mockNamespace,
+        mockGroupId,
+        undefined,
+        ''
+      );
+
+      expect(getItemsFromGroupSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('URL path should contain maxItems if the query parameter is provided', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation((path, timeout, metricType) => {
+        expect(path).toContain(`?maxItems=${maxItems}`);
+        expect(path).toContain(
+          `${ekvService.EDGEKV_API_BASE}/networks/${mockNetwork}/namespaces/${mockNamespace}/groups/${mockGroupId}`
+        );
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.readItemsFromGroup);
+
+        return Promise.resolve({
+          body: mockResponse,
+        });
+      });
+
+      const getItemsFromGroupSpy = jest.spyOn(ekvService, 'getItemsFromGroup');
+      const res = await ekvService.getItemsFromGroup(
+        mockNetwork,
+        mockNamespace,
+        mockGroupId,
+        maxItems,
+        ''
+      );
+
+      expect(getItemsFromGroupSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('URL path should not contain sandboxId if the query parameter is not provided', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation((path, timeout, metricType) => {
+        expect(path).not.toContain('?sandboxId=');
+        expect(path).toContain(
+          `${ekvService.EDGEKV_API_BASE}/networks/${mockNetwork}/namespaces/${mockNamespace}/groups/${mockGroupId}`
+        );
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.readItemsFromGroup);
+
+        return Promise.resolve({
+          body: mockResponse,
+        });
+      });
+
+      const getItemsFromGroupSpy = jest.spyOn(ekvService, 'getItemsFromGroup');
+      const res = await ekvService.getItemsFromGroup(
+        mockNetwork,
+        mockNamespace,
+        mockGroupId,
+        undefined,
+        undefined
+      );
+
+      expect(getItemsFromGroupSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('URL path should contain sandboxId if the query parameter is provided', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation((path, timeout, metricType) => {
+        expect(path).toContain('?sandboxId=');
+        expect(path).toContain(
+          `${ekvService.EDGEKV_API_BASE}/networks/${mockNetwork}/namespaces/${mockNamespace}/groups/${mockGroupId}`
+        );
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.readItemsFromGroup);
+
+        return Promise.resolve({
+          body: mockResponse,
+        });
+      });
+
+      const getItemsFromGroupSpy = jest.spyOn(ekvService, 'getItemsFromGroup');
+      const res = await ekvService.getItemsFromGroup(
+        mockNetwork,
+        mockNamespace,
+        mockGroupId,
+        undefined,
+        mockSandboxId
+      );
+
+      expect(getItemsFromGroupSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('URL path should contain maxItems and sandboxId if both query parameters are provided', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation((path, timeout, metricType) => {
+        expect(path).toContain(
+          `?maxItems=${maxItems}&sandboxId=${mockSandboxId}`
+        );
+        expect(path).toContain(
+          `${ekvService.EDGEKV_API_BASE}/networks/${mockNetwork}/namespaces/${mockNamespace}/groups/${mockGroupId}`
+        );
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.readItemsFromGroup);
+
+        return Promise.resolve({
+          body: mockResponse,
+        });
+      });
+
+      const getItemsFromGroupSpy = jest.spyOn(ekvService, 'getItemsFromGroup');
+      const res = await ekvService.getItemsFromGroup(
+        mockNetwork,
+        mockNamespace,
+        mockGroupId,
+        maxItems,
+        mockSandboxId
+      );
+
+      expect(getItemsFromGroupSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('function should handle errors properly', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation(() => {
+        // The normal error object will be returned as a string
+        return Promise.reject(JSON.stringify(mockError));
+      });
+
+      const getItemsFromGroupSpy = jest.spyOn(ekvService, 'getItemsFromGroup');
+      const error = await ekvService.getItemsFromGroup(
+        mockNetwork,
+        mockNamespace,
+        mockGroupId,
+        undefined,
+        ''
+      );
+
+      expect(getItemsFromGroupSpy).toHaveBeenCalled();
+      // Check the details of error object
+      expect(error).not.toBeUndefined;
+      expect(error.isError).toEqual(true);
+      expect(error.status).toEqual(mockError.status);
+      expect(error.error_reason).toEqual(mockError.detail);
+      expect(error.traceId).toEqual(mockError.traceId);
+    });
+  });
+
+  describe('testing createEdgeKVToken', () => {
+    const mockReqBody = {
+      name: mockTokenName,
+      allowOnStaging: true,
+      allowOnProduction: false,
+      restrictToEwids: mockEwids,
+      expiry: mockExpiry,
+      namespacePermissions: mockPermissionList,
+    };
+    const mockResponse = {
+      statusCode: 201,
+      message: 'created',
+    };
+
+    test('response should return creation success', async () => {
+      // Mock postJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'postJson');
+      getJsonSpy.mockImplementation((path, body, timeout, metricType) => {
+        expect(path).toContain(`${ekvService.EDGEKV_API_BASE}/tokens`);
+        expect(body).toEqual(mockReqBody);
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.createToken);
+
+        return Promise.resolve({
+          body: mockResponse,
+        });
+      });
+
+      const creationSpy = jest.spyOn(ekvService, 'createEdgeKVToken');
+      const res = await ekvService.createEdgeKVToken(
+        mockTokenName,
+        mockPermissionList,
+        true,
+        false,
+        mockEwids,
+        mockExpiry
+      );
+
+      expect(creationSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('function should handle errors properly', async () => {
+      // Mock postJson() method
+      const postJsonSpy = jest.spyOn(httpEdge, 'postJson');
+      postJsonSpy.mockImplementation(() => {
+        // The normal error object will be returned as a string
+        return Promise.reject(JSON.stringify(mockError));
+      });
+
+      const createEdgeKVTokenSpy = jest.spyOn(ekvService, 'createEdgeKVToken');
+      const error = await ekvService.createEdgeKVToken(
+        mockTokenName,
+        mockPermissionList,
+        true,
+        false,
+        mockEwids,
+        mockExpiry
+      );
+
+      expect(createEdgeKVTokenSpy).toHaveBeenCalled();
+      // Check the details of error object
+      expect(error).not.toBeUndefined;
+      expect(error.isError).toEqual(true);
+      expect(error.status).toEqual(mockError.status);
+      expect(error.error_reason).toEqual(mockError.detail);
+      expect(error.traceId).toEqual(mockError.traceId);
+    });
+  });
+
+  describe('testing getSingleToken', () => {
+    const mockResponse = {
+      statusCode: 200,
+      mockToken: 'mocktoken',
+    };
+
+    test('response should return single token success', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation((path, timeout, metricType) => {
+        expect(path).toContain(
+          `${ekvService.EDGEKV_API_BASE}/tokens/${mockTokenName}`
+        );
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.readToken);
+
+        return Promise.resolve({
+          body: mockResponse,
+        });
+      });
+
+      const getSingleTokenSpy = jest.spyOn(ekvService, 'getSingleToken');
+      const res = await ekvService.getSingleToken(mockTokenName);
+
+      expect(getSingleTokenSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('function should handle errors properly', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation(() => {
+        // The normal error object will be returned as a string
+        return Promise.reject(JSON.stringify(mockError));
+      });
+
+      const getSingleTokenSpy = jest.spyOn(ekvService, 'getSingleToken');
+      const error = await ekvService.getSingleToken(mockTokenName);
+
+      expect(getSingleTokenSpy).toHaveBeenCalled();
+      // Check the details of error object
+      expect(error).not.toBeUndefined;
+      expect(error.isError).toEqual(true);
+      expect(error.status).toEqual(mockError.status);
+      expect(error.error_reason).toEqual(mockError.detail);
+      expect(error.traceId).toEqual(mockError.traceId);
+    });
+  });
+
+  describe('testing getTokenList', () => {
+    const mockResponse = {
+      statusCode: 200,
+      mockTokens: ['token1', 'token2', 'token3'],
+    };
+
+    test('URL path should not include includeExpired query parameter if passing false', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation((path, timeout, metricType) => {
+        expect(path).not.toContain('?includeExpired');
+        expect(path).toContain(`${ekvService.EDGEKV_API_BASE}/tokens`);
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.readTokenList);
+
+        return Promise.resolve({
+          body: mockResponse,
+        });
+      });
+
+      const getTokenListSpy = jest.spyOn(ekvService, 'getTokenList');
+      const res = await ekvService.getTokenList(false);
+
+      expect(getTokenListSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('URL path should include includeExpired query parameter if passing true', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation((path, timeout, metricType) => {
+        expect(path).toContain(
+          `${ekvService.EDGEKV_API_BASE}/tokens?includeExpired=true`
+        );
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.readTokenList);
+
+        return Promise.resolve({
+          body: mockResponse,
+        });
+      });
+
+      const getTokenListSpy = jest.spyOn(ekvService, 'getTokenList');
+      const res = await ekvService.getTokenList(true);
+
+      expect(getTokenListSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('function should handle errors properly', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation(() => {
+        // The normal error object will be returned as a string
+        return Promise.reject(JSON.stringify(mockError));
+      });
+
+      const getTokenListSpy = jest.spyOn(ekvService, 'getTokenList');
+      const error = await ekvService.getTokenList(false);
+
+      expect(getTokenListSpy).toHaveBeenCalled();
+      // Check the details of error object
+      expect(error).not.toBeUndefined;
+      expect(error.isError).toEqual(true);
+      expect(error.status).toEqual(mockError.status);
+      expect(error.error_reason).toEqual(mockError.detail);
+      expect(error.traceId).toEqual(mockError.traceId);
+    });
+  });
+
+  describe('testing revokeToken', () => {
+    const mockResponse = {
+      statusCode: 204,
+    };
+
+    test('response should revoke token success', async () => {
+      // Mock deleteReq() method
+      const deleteReqSpy = jest.spyOn(httpEdge, 'deleteReq');
+      deleteReqSpy.mockImplementation((path, timeout, metricType) => {
+        expect(path).toContain(
+          `${ekvService.EDGEKV_API_BASE}/tokens/${mockTokenName}`
+        );
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.deleteToken);
+
+        return Promise.resolve({
+          body: mockResponse,
+        });
+      });
+
+      const revokeTokenSpy = jest.spyOn(ekvService, 'revokeToken');
+      const res = await ekvService.revokeToken(mockTokenName);
+
+      expect(revokeTokenSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('function should handle errors properly', async () => {
+      // Mock deleteReq() method
+      const deleteReqSpy = jest.spyOn(httpEdge, 'deleteReq');
+      deleteReqSpy.mockImplementation(() => {
+        // The normal error object will be returned as a string
+        return Promise.reject(JSON.stringify(mockError));
+      });
+
+      const revokeTokenSpy = jest.spyOn(ekvService, 'revokeToken');
+      const error = await ekvService.revokeToken(mockTokenName);
+
+      expect(revokeTokenSpy).toHaveBeenCalled();
+      // Check the details of error object
+      expect(error).not.toBeUndefined;
+      expect(error.isError).toEqual(true);
+      expect(error.status).toEqual(mockError.status);
+      expect(error.error_reason).toEqual(mockError.detail);
+      expect(error.traceId).toEqual(mockError.traceId);
+    });
+  });
+
+  describe('testing modifyAuthGroupPermission', () => {
+    const mockReqBody = {
+      groupId: mockAuthGroupId,
+    };
+    const mockResponse = {
+      statusCode: 200,
+      permissions: ['abc', 'def'],
+    };
+
+    test('response should modify permissions successfully', async () => {
+      // Mock putJson() method
+      const putJsonSpy = jest.spyOn(httpEdge, 'putJson');
+      putJsonSpy.mockImplementation((path, body, timeout, metricType) => {
+        expect(path).toContain(
+          `${ekvService.EDGEKV_API_BASE}/auth/namespaces/${mockNamespace}`
+        );
+        expect(body).toEqual(mockReqBody);
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.modifyAuthGroup);
+
+        return Promise.resolve({
+          body: mockResponse,
+        });
+      });
+
+      const modifyAuthGroupPermissionSpy = jest.spyOn(
+        ekvService,
+        'modifyAuthGroupPermission'
+      );
+      const res = await ekvService.modifyAuthGroupPermission(
+        mockNamespace,
+        mockAuthGroupId
+      );
+
+      expect(modifyAuthGroupPermissionSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('function should handle errors properly', async () => {
+      // Mock putJson() method
+      const putJsonSpy = jest.spyOn(httpEdge, 'putJson');
+      putJsonSpy.mockImplementation(() => {
+        // The normal error object will be returned as a string
+        return Promise.reject(JSON.stringify(mockError));
+      });
+
+      const modifyAuthGroupPermissionSpy = jest.spyOn(
+        ekvService,
+        'modifyAuthGroupPermission'
+      );
+      const error = await ekvService.modifyAuthGroupPermission(
+        mockNamespace,
+        mockAuthGroupId
+      );
+
+      expect(modifyAuthGroupPermissionSpy).toHaveBeenCalled();
+      // Check the details of error object
+      expect(error).not.toBeUndefined;
+      expect(error.isError).toEqual(true);
+      expect(error.status).toEqual(mockError.status);
+      expect(error.error_reason).toEqual(mockError.detail);
+      expect(error.traceId).toEqual(mockError.traceId);
+    });
+  });
+
+  describe('testing listAuthGroups', () => {
+    const mockResponse = {
+      statusCode: 200,
+      authGroups: ['group1', 'group2', 'group3'],
+    };
+
+    test('URL path should not include groupId when passing 0', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation((path, timeout, metricType) => {
+        expect(path).not.toContain('/groups/0');
+        expect(path).toContain(`${ekvService.EDGEKV_API_BASE}/auth/groups`);
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.listAuthGroup);
+
+        return Promise.resolve({
+          body: mockResponse,
+        });
+      });
+
+      const listAuthGroupsSpy = jest.spyOn(ekvService, 'listAuthGroups');
+      const res = await ekvService.listAuthGroups(0);
+
+      expect(listAuthGroupsSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('URL path should include include groupId when passing non-zero value', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation((path, timeout, metricType) => {
+        expect(path).toContain(`${ekvService.EDGEKV_API_BASE}/auth/groups/2`);
+        expect(timeout).toEqual(defaultTimeout);
+        expect(metricType).toEqual(ekvMetrics.listAuthGroup);
+
+        return Promise.resolve({
+          body: mockResponse,
+        });
+      });
+
+      const listAuthGroupsSpy = jest.spyOn(ekvService, 'listAuthGroups');
+      const res = await ekvService.listAuthGroups(2);
+
+      expect(listAuthGroupsSpy).toHaveBeenCalled();
+      expect(res).toEqual(mockResponse);
+    });
+
+    test('function should handle errors properly', async () => {
+      // Mock getJson() method
+      const getJsonSpy = jest.spyOn(httpEdge, 'getJson');
+      getJsonSpy.mockImplementation(() => {
+        // The normal error object will be returned as a string
+        return Promise.reject(JSON.stringify(mockError));
+      });
+
+      const listAuthGroupsSpy = jest.spyOn(ekvService, 'listAuthGroups');
+      const error = await ekvService.listAuthGroups(mockAuthGroupId);
+
+      expect(listAuthGroupsSpy).toHaveBeenCalled();
+      // Check the details of error object
+      expect(error).not.toBeUndefined;
+      expect(error.isError).toEqual(true);
+      expect(error.status).toEqual(mockError.status);
+      expect(error.error_reason).toEqual(mockError.detail);
+      expect(error.traceId).toEqual(mockError.traceId);
+    });
+  });
+});

--- a/tests/edgekv/items.json
+++ b/tests/edgekv/items.json
@@ -1,0 +1,5 @@
+{
+  "item1": "item1",
+  "item2": "item2",
+  "item3": "item3"
+}


### PR DESCRIPTION
### Major Change
- Fix issues that double quotes will be added to the string values in backend
- Add unit tests for ekv-services
- Bump up the CLI version to `1.5.2`

### Test Results (See `testing writeItems` case):
```
jest ./tests/edgekv                                                                        
 PASS  tests/edgekv/ekv-services.test.ts
  ekv-services tests
    testing getNameSpaceList
      ✓ URL path should not include query parameter when details parameter is false (1 ms)
      ✓ URL path should contian query parameter when details parameter is true (1 ms)
      ✓ function should handle errors properly
    testing getGroupsList
      ✓ response should return groups list
      ✓ function should handle errors properly
    testing createNameSpace
      ✓ response should return created namespace (1 ms)
      ✓ function should handle errors properly
    testing getNameSpace
      ✓ response should return namespace info (1 ms)
      ✓ function should handle errors properly
    testing updateNameSpace
      ✓ response should return changed namespace info (1 ms)
      ✓ function should handle errors properly
    testing initializeEdgeKV
      ✓ response should return initialization success
      ✓ function should handle errors properly (1 ms)
    testing getInitializeEdgeKV
      ✓ response should return initialization success (2 ms)
      ✓ function should handle errors properly
    testing wrtieItems
      ✓ URL path should not contain sandboxId if the query parameter is not provided (1 ms)
      ✓ URL path should contain sandboxId if the query parameter is provided
      ✓ response should return writeItems success when body is a JSON object string
      ✓ function should handle errors properly
    testing wrtieItemsFromFile
      ✓ URL path should not contain sandboxId if the query parameter is not provided (1 ms)
      ✓ URL path should contain sandboxId if the query parameter is provided (1 ms)
      ✓ function should handle errors properly
    testing readItem
      ✓ URL path should not contain sandboxId if the query parameter is not provided (1 ms)
      ✓ URL path should contain sandboxId if the query parameter is provided
      ✓ function should handle errors properly
    testing deleteItem
      ✓ URL path should not contain sandboxId if the query parameter is not provided (1 ms)
      ✓ URL path should contain sandboxId if the query parameter is provided
      ✓ function should handle errors properly
    testing getItemsFromGroup
      ✓ URL path should not contain maxItems if the query parameter is not provided
      ✓ URL path should contain maxItems if the query parameter is provided
      ✓ URL path should not contain sandboxId if the query parameter is not provided
      ✓ URL path should contain sandboxId if the query parameter is provided
      ✓ URL path should contain maxItems and sandboxId if both query parameters are provided
      ✓ function should handle errors properly
    testing createEdgeKVToken
      ✓ response should return creation success
      ✓ function should handle errors properly
    testing getSingleToken
      ✓ response should return single token success
      ✓ function should handle errors properly
    testing getTokenList
      ✓ URL path should not include includeExpired query parameter if passing false
      ✓ URL path should include includeExpired query parameter if passing true (1 ms)
      ✓ function should handle errors properly (1 ms)
    testing revokeToken
      ✓ response should revoke token success
      ✓ function should handle errors properly
    testing modifyAuthGroupPermission
      ✓ response should modify permissions successfully (1 ms)
      ✓ function should handle errors properly
    testing listAuthGroups
      ✓ URL path should not include groupId when passing 0
      ✓ URL path should include include groupId when passing non-zero value
      ✓ function should handle errors properly (1 ms)

Test Suites: 1 passed, 1 total
Tests:       48 passed, 48 total
Snapshots:   0 total
Time:        1.088 s
```