### PR TITLE
EW-13175: EdgeKV CLI should output a proper error message for bad retention input

### DIFF
--- a/docs/edgekv_cli.md
+++ b/docs/edgekv_cli.md
@@ -170,6 +170,7 @@ Usage: `akamai edgekv create ns <environment> <nameSpace>`
 2. The namespace identifier can be between 1 and 32 characters in length.
 3. You cannot use the word "default" as the namespace identifier. The “default” namespace is already created during initialization.
 4. Specifying "0" retention means indefinite retention.
+5. A non-zero retention cannot be less than 1 day or more than 3650 days.
 
 ### List NameSpace
 
@@ -216,6 +217,7 @@ Usage: `akamai edgekv modify ns <environment> <nameSpace>`
 1. The namespace identifier can only include alphanumeric (0-9, a-z, A-Z), underscore (_), and (-) dash characters.
 2. The namespace identifier can be between 1 and 32 characters in length.
 3. You cannot modify the retention period for the "default" namespace.
+4. A non-zero retention cannot be less than 1 day or more than 3650 days.
 
 ### Create or Update item
 

--- a/src/edgekv/ekv-helper.ts
+++ b/src/edgekv/ekv-helper.ts
@@ -356,6 +356,10 @@ export function getDateDifference(date) {
 
 export function convertDaysToSeconds(days: number) {
     if (!isNaN(days) && days >= 0) {
+        if (days != 0 && (days < 1 || days > 3650)){
+            // Retention cannot be less than 86400 sec (1 day) or more than 315360000 sec (3650 days)
+            cliUtils.logAndExit(1, `ERROR: A non zero value specified for the retention period cannot be less than 1 day or more than 3650 days.`);
+        }
         return days * 86400;
     } else {
         cliUtils.logAndExit(1, "ERROR: Retention period specified is invalid. Please specify the retention in number of days.");

--- a/src/edgekv/ekv-helper.ts
+++ b/src/edgekv/ekv-helper.ts
@@ -357,7 +357,7 @@ export function getDateDifference(date) {
 export function convertDaysToSeconds(days: number) {
     if (!isNaN(days) && days >= 0) {
         if (days != 0 && (days < 1 || days > 3650)){
-            // Retention cannot be less than 86400 sec (1 day) or more than 315360000 sec (3650 days)
+            // Retention must be either zero or in the range of 86400 sec (1 day) to 315360000 sec (3650 days)
             cliUtils.logAndExit(1, `ERROR: A non zero value specified for the retention period cannot be less than 1 day or more than 3650 days.`);
         }
         return days * 86400;

--- a/tests/edgekv/ekv-services.test.ts
+++ b/tests/edgekv/ekv-services.test.ts
@@ -313,7 +313,7 @@ describe('ekv-services tests', () => {
         mockNetwork,
         mockNamespace,
         retention,
-        0,
+        groupId,
         geoLocation
       );
 

--- a/tests/edgekv/ekv-services.test.ts
+++ b/tests/edgekv/ekv-services.test.ts
@@ -262,9 +262,11 @@ describe('ekv-services tests', () => {
   describe('testing updateNameSpace', () => {
     const retention = 1000;
     const geoLocation = 'mockLocation';
+    const groupId = 0;
     const mockReqBody = {
       namespace: mockNamespace,
       retentionInSeconds: retention,
+      groupId: groupId,
       geoLocation: geoLocation,
     };
     const mockResBody = { message: 'success' };
@@ -290,6 +292,7 @@ describe('ekv-services tests', () => {
         mockNetwork,
         mockNamespace,
         retention,
+        groupId,
         geoLocation
       );
 
@@ -310,6 +313,7 @@ describe('ekv-services tests', () => {
         mockNetwork,
         mockNamespace,
         retention,
+        0,
         geoLocation
       );
 


### PR DESCRIPTION
- Validate retention period duration before calling API
- Fix a few broken tests in `ekv-services.test.ts`