### PR TITLE
EW-13500: Namespace List Enhancements for EdgeKV CLI

### DIFF
--- a/docs/edgekv_cli.md
+++ b/docs/edgekv_cli.md
@@ -182,6 +182,9 @@ Usage: `akamai edgekv list ns <environment>`
 | - | - |
 | -h, --help  | Display information on how to use this EdgeKV command. |
 | -d, --details | Displays details of the namespace. |
+| --order-by | Choose column to order by when displaying detailed namespace list. |
+| --asc, --ascending | Sort using acscending order (default). |
+| --desc, --descending | Sort using descending order. |
 
 | Argument | Existence | Description |
 | - | - | - |

--- a/src/edgekv/ekv-cli-main.ts
+++ b/src/edgekv/ekv-cli-main.ts
@@ -201,10 +201,61 @@ list
     '-d, --details',
     'Setting this option will provide the namespace details'
   )
+  .option(
+    '--order-by <columnName>',
+    'Specify the column to order the list of namespaces by'
+  )
+  .option(
+    '--asc, --ascending',
+    'Set the sort direction to ascending order'
+  )
+  .option(
+    '--desc, --descending',
+    'Set the sort direction to descending order'
+  )
   .description('List all the namespaces')
   .action(async function (environment, options) {
+    let sortDirection: cliUtils.sortDirections, orderBy: string;
+
+    if (options.ascending && options.descending) {
+      cliUtils.logAndExit(1, 'ERROR: Cannot set both ascending and descending sort together.');
+    } else if (options.descending) {
+      sortDirection = cliUtils.sortDirections.DESC;
+    } else {
+      sortDirection = cliUtils.sortDirections.ASC;
+    }
+
+    // map sort column to object properties
+    if (options.orderBy) {
+      if (!options.details){
+        cliUtils.logAndExit(1, 'ERROR: Cannot use order-by without using detailed list.');
+      }
+      switch(options.orderBy.toLowerCase()){
+        case 'namespaceid':
+        case 'namespace':
+          orderBy = 'namespace';
+          break;
+        case 'retentionperiod':
+        case 'retention':
+          orderBy = 'retentionInSeconds';
+          break;
+        case 'geolocation':
+          orderBy = 'geoLocation';
+          break;
+        case 'accessgroupid':
+        case 'groupid':
+          orderBy = 'groupId';
+          break;
+        default:
+          cliUtils.logAndExit(1, `ERROR: Column ${options.orderBy} is not a valid column name.`);
+          break;
+      }
+    } else {
+      orderBy = 'namespace';
+    }
+
     try {
-      await kvCliHandler.listNameSpaces(environment, options.details);
+      await kvCliHandler.listNameSpaces(environment, options.details, sortDirection, orderBy);
     } catch (e) {
       cliUtils.logAndExit(1, e);
     }

--- a/src/edgekv/ekv-handler.ts
+++ b/src/edgekv/ekv-handler.ts
@@ -4,30 +4,32 @@ import * as response from './ekv-response';
 import * as ekvhelper from './ekv-helper';
 import * as edgeWorkersSvc from '../edgeworkers/ew-service';
 
-export async function listNameSpaces(environment: string, details) {
+export async function listNameSpaces(environment: string, details: boolean, sortDirection: cliUtils.sortDirections, orderBy: string) {
   ekvhelper.validateNetwork(environment);
-  let nameSpaceList = await cliUtils.spinner(
+  const nameSpaceList = await cliUtils.spinner(
     edgekvSvc.getNameSpaceList(environment, details),
     'Fetching namespace list...'
   );
   if (nameSpaceList != undefined && !nameSpaceList.isError) {
-    let nsListResp = [];
+    const nsListResp = [];
     if (nameSpaceList.hasOwnProperty('namespaces')) {
-      let namespace = nameSpaceList['namespaces'];
+      const namespace = nameSpaceList['namespaces'];
+      cliUtils.sortObjectArray(namespace, orderBy, sortDirection);
+
       namespace.forEach(function (value) {
         if (details) {
-          let retentionPeriod = ekvhelper.convertRetentionPeriod(
+          const retentionPeriod = ekvhelper.convertRetentionPeriod(
             value['retentionInSeconds']
           );
-          let groupId = value['groupId'] == undefined ? 0 : value['groupId'];
+          const groupId = value['groupId'] == undefined ? 0 : value['groupId'];
           nsListResp.push({
-            Namespace: value['namespace'],
+            NamespaceId: value['namespace'],
             RetentionPeriod: retentionPeriod,
             GeoLocation: value['geoLocation'],
-            'Access GroupId': groupId,
+            AccessGroupId: groupId,
           });
         } else {
-          nsListResp.push({ Namespace: value['namespace'] });
+          nsListResp.push({ NamespaceId: value['namespace'] });
         }
       });
     }

--- a/src/utils/cli-utils.ts
+++ b/src/utils/cli-utils.ts
@@ -220,3 +220,30 @@ function bytesToSize(bytes: number, decimals: number = 2, kilobyte: number = 102
 
   return `${Number(res).toString()} ${MEMORY_UNITS[i]}`;
 }
+
+export enum sortDirections {
+  ASC = 'ASC',
+  DESC = 'DESC'
+}
+
+export function sortObjectArray (objArray: Array<object>, key: string, sortDirection: sortDirections) {
+  objArray.sort( (a, b) => {
+      let valA, valB;
+      
+      if (typeof a[key] === 'string' && typeof b[key] === 'string'){
+          valA = a[key].toUpperCase();
+          valB = b[key].toUpperCase();
+      } else {
+          valA = a[key];
+          valB = b[key];
+      }
+      
+      if (valA < valB) {
+          return sortDirection === sortDirections.DESC ? 1 : -1;
+      } else if (valA > valB) {
+          return sortDirection === sortDirections.DESC ? -1 : 1;
+      } else {
+          return 0;
+      }
+    });
+}


### PR DESCRIPTION
This PR adds the ability to sort the list namespace output when using the `--details` option.
- user can choose the column to sort using `--order-by` (sorts the namespace column by default)
- can sort using `--asc` or `--desc` order
- renamed namespace to namespace id to be consistent with API docs

