### PR TITLE
EW-8179: Add jsonout flag for json to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Options:
 | --section `<name>` | Use this section in `edgerc` file. (Default section is _[default]_)|
 | --timeout `<timeout>` | You can specify a timeout value for a command in seconds to override the 2 minute default. For example, if you add "--timeout 10" to a command, it will timeout if the server takes more than 10 second to respond. |
 | --json `[path]` | Write CLI output as JSON to optionally provided path.  If not path provided, write JSON output to CLI home directory |
+| --jsonout | Write CLI output as JSON to stdout. |
 | -h, --help | Display usage information for EdgeWorkers CLI. |
  
 Commands:

--- a/src/edgeworkers/client-manager.ts
+++ b/src/edgeworkers/client-manager.ts
@@ -22,19 +22,21 @@ const EDGEWORKERS_CLI_OUTPUT_DIR: string = path.join(
   EDGEWORKERS_DIR,
   `/cli-output/${Date.now()}/`
 );
-const EDGEWORKERS_CLI_OUTPUT_FILENAME: string = 'ewcli_output.json';
-const MAINJS_FILENAME: string = 'main.js';
-const MANIFEST_FILENAME: string = 'bundle.json';
-const TARBALL_VERSION_KEY: string = 'edgeworker-version';
-const BUNDLE_FORMAT_VERSION_KEY: string = 'bundle-version';
-const JSAPI_VERSION_KEY: string = 'api-version';
-var tarballChecksum = undefined;
+const EDGEWORKERS_CLI_OUTPUT_FILENAME = 'ewcli_output.json';
+const MAINJS_FILENAME = 'main.js';
+const MANIFEST_FILENAME = 'bundle.json';
+const TARBALL_VERSION_KEY = 'edgeworker-version';
+const BUNDLE_FORMAT_VERSION_KEY = 'bundle-version';
+const JSAPI_VERSION_KEY = 'api-version';
+let tarballChecksum;
 
 // set default JSON output options
 const jsonOutputParams = {
   jsonOutput: false,
   jsonOutputPath: EDGEWORKERS_CLI_OUTPUT_DIR,
   jsonOutputFilename: EDGEWORKERS_CLI_OUTPUT_FILENAME,
+  jsonOutputFile: false,
+  jsonOutputStdout: false
 };
 
 // Add try/catch logic incase user doesnt have permissions to write directories needed
@@ -65,12 +67,27 @@ export function setJSONOutputMode(output: boolean) {
 }
 
 export function setJSONOutputPath(path: string) {
+  jsonOutputParams.jsonOutputFile = true;
   // only set path to new value if it is provided; since its optional, could be null, so leave set to default value
-  if (path) jsonOutputParams.jsonOutputPath = untildify(path);
+  if (path) { 
+    jsonOutputParams.jsonOutputPath = untildify(path);
+  }
+}
+
+export function setJSONOutputStdout(output: boolean) {
+  jsonOutputParams.jsonOutputStdout = output;
 }
 
 export function isJSONOutputMode() {
   return jsonOutputParams.jsonOutput;
+}
+
+export function isJSONOutputStdout() {
+  return jsonOutputParams.jsonOutputStdout;
+}
+
+export function isJSONOutputFile() {
+  return jsonOutputParams.jsonOutputFile;
 }
 
 /**
@@ -83,11 +100,11 @@ export function validateTarballLocally(
   rawTarballPath: string,
   isValidate?: boolean
 ) {
-  var tarballPath = untildify(rawTarballPath);
+  const tarballPath = untildify(rawTarballPath);
 
   // Check to make sure tarball exists
   if (!fs.existsSync(tarballPath)) {
-    let errMsgPart = isValidate
+    const errMsgPart = isValidate
       ? 'Validation Errors for:'
       : 'ERROR: EdgeWorkers bundle archive';
     cliUtils.logAndExit(
@@ -106,9 +123,9 @@ export function validateTarballLocally(
 }
 
 export function buildTarball(ewId: string, codePath: string) {
-  var codeWorkingDirectory = untildify(codePath);
-  var mainjsPath = path.join(codeWorkingDirectory, MAINJS_FILENAME);
-  var manifestPath = path.join(codeWorkingDirectory, MANIFEST_FILENAME);
+  const codeWorkingDirectory = untildify(codePath);
+  const mainjsPath = path.join(codeWorkingDirectory, MAINJS_FILENAME);
+  const manifestPath = path.join(codeWorkingDirectory, MANIFEST_FILENAME);
 
   if (!fs.existsSync(mainjsPath) || !fs.existsSync(manifestPath)) {
     cliUtils.logAndExit(
@@ -120,12 +137,12 @@ export function buildTarball(ewId: string, codePath: string) {
   const edgeWorkersDir = createEdgeWorkerIdDir(ewId);
 
   // Build tarball file name as ew_<version>_<now-as-epoch>.tgz
-  var tarballFileName: string = 'ew_';
-  var tarballVersion: string;
+  let tarballFileName = 'ew_';
+  let tarballVersion: string;
 
   // Validate Manifest and if valid, grab version identifier
-  var manifest = fs.readFileSync(manifestPath).toString();
-  var manifestValidationData = validateManifest(manifest);
+  const manifest = fs.readFileSync(manifestPath).toString();
+  const manifestValidationData = validateManifest(manifest);
 
   if (!manifestValidationData.isValid) {
     cliUtils.logAndExit(1, manifestValidationData.error_reason);
@@ -191,9 +208,9 @@ function validateManifest(manifest: string) {
 
   manifest = JSON.parse(manifest);
 
-  var tarballVersion = manifest[TARBALL_VERSION_KEY];
-  var manifestFormat = manifest[BUNDLE_FORMAT_VERSION_KEY];
-  var jsAPIVersion = manifest[JSAPI_VERSION_KEY];
+  const tarballVersion = manifest[TARBALL_VERSION_KEY];
+  const manifestFormat = manifest[BUNDLE_FORMAT_VERSION_KEY];
+  const jsAPIVersion = manifest[JSAPI_VERSION_KEY];
 
   // only checks the one required field is found, ignores optional fields (for now)
   if (!tarballVersion) {
@@ -253,7 +270,7 @@ export function determineTarballDownloadDir(
 ) {
   // If download path option provided, try to use it
   // If not provided, default to CLI cache directory under <CLI_CACHE_PATH>/edgeworkers-cli/edgeworkers/<ewid>/
-  var downloadPath = !!rawDownloadPath
+  const downloadPath = rawDownloadPath
     ? untildify(rawDownloadPath)
     : createEdgeWorkerIdDir(ewId);
 
@@ -315,9 +332,6 @@ function determineJSONOutputPathAndFilename() {
     );
   }
 
-  console.log(
-    `Saving JSON output at: ${path.join(jsonOutputPath, jsonOutputFilename)}`
-  );
   return {
     path: jsonOutputPath,
     filename: jsonOutputFilename,
@@ -338,23 +352,36 @@ export function writeJSONOutput(exitCode: number, msg: string, data = {}) {
     outputData = data;
   }
 
-  let output = {
+  const output = {
     cliStatus: exitCode,
     msg: outputMsg,
     data: outputData,
   };
 
-  // Then, determine the path and filename to write the JSON output
-  let outputDestination = determineJSONOutputPathAndFilename();
-  // Last, try to write the output file synchronously
-  try {
-    fs.writeFileSync(
-      path.join(outputDestination.path, outputDestination.filename),
-      cliUtils.toJsonPretty(output)
-    );
-  } catch (e) {
-    // unset JSON mode since we cant write the file before writing out error
-    setJSONOutputMode(false);
-    cliUtils.logAndExit(1, `ERROR: Cannot create JSON output \n${e.message}`);
+  const jsonResult = cliUtils.toJsonPretty(output);
+
+  // Check if we should output JSON to stdout
+  if (isJSONOutputStdout()) {
+    console.log(jsonResult);
+  }
+
+  if (isJSONOutputFile()) {
+    // Determine the path and filename to write the JSON output
+    const outputDestination = determineJSONOutputPathAndFilename();
+    // Last, try to write the output file synchronously
+    try {
+      // support writing to both file and stdout; if stdout is on, don't leave a log message
+      if (!isJSONOutputStdout()) {
+        console.log(`Saving JSON output at: ${path.join(outputDestination.path, outputDestination.filename)}`);
+      }
+      fs.writeFileSync(
+        path.join(outputDestination.path, outputDestination.filename),
+        jsonResult
+      );
+    } catch (e) {
+      // unset JSON mode since we cant write the file before writing out error
+      setJSONOutputMode(false);
+      cliUtils.logAndExit(1, `ERROR: Cannot create JSON output \n${e.message}`);
+    }
   }
 }

--- a/src/edgeworkers/ew-cli-main.ts
+++ b/src/edgeworkers/ew-cli-main.ts
@@ -17,6 +17,7 @@ program
   .option('--edgerc <path>', 'Use edgerc file for authentication.')
   .option('--section <name>', 'Use this section in edgerc file that contains the credential set.')
   .option('--json [path]', 'Write command output to JSON file at given path, otherwise written to CLI cache directory')
+  .option('--jsonout', 'Write command output as JSON to stdout')
   .option('--accountkey <account-id>', 'internal parameter')
   .option('--timeout <timeout>', 'Use this for custom timeout')
   .on("option:debug", function () {
@@ -31,6 +32,10 @@ program
   .on("option:json", function (path) {
     edgeWorkersClientSvc.setJSONOutputMode(true);
     edgeWorkersClientSvc.setJSONOutputPath(path);
+  })
+  .on("option:jsonout", function () {
+    edgeWorkersClientSvc.setJSONOutputMode(true);
+    edgeWorkersClientSvc.setJSONOutputStdout(true);
   })
   .on("option:accountkey", function (key) {
     httpEdge.setAccountKey(key);


### PR DESCRIPTION
This PR allows the CLI to output the json response directly to stdout using the `--jsonout` option.
Users can also combine both the existing `--json` and new `--jsonout` options together.