### PR TITLE
EW-13257: Fix explicitly added double quotes not showing when reading EdgeKv items

### DIFF
--- a/tests/cli-httpRequest.test.ts
+++ b/tests/cli-httpRequest.test.ts
@@ -48,6 +48,10 @@ describe('cli-httpRequest tests', () => {
       setAccountKey(key);
       expect(accountKey).toBe('testKey');
     });
+
+    afterAll(() => {
+      setAccountKey('');
+    });
   });
 
   describe('testing sendEdgeRequest', () => {
@@ -65,7 +69,43 @@ describe('cli-httpRequest tests', () => {
         console.error(err);
       });
 
-      expect(authSpy).toHaveBeenCalled();
+      expect(authSpy).toHaveBeenCalledWith({
+        path: PATH,
+        method: GET_METHOD,
+        body: BODY,
+        headers: HEADERS,
+      });
+      expect(sendSpy).toHaveBeenCalled();
+      expect(result.err).toBeUndefined();
+      expect(result.response.status).toEqual(SUCCESS_CODE);
+    });
+
+    test('should call edge.auth with the optional requestConfig', async () => {
+      const authSpy = jest.spyOn(EdgeGrid.prototype, 'auth');
+      const sendSpy = jest.spyOn(EdgeGrid.prototype, 'send');
+
+      const metricType = 'myMetric';
+      const requestConfig = { key1: 'requestValue1', key2: 'requestValue2'};
+
+      const result = await sendEdgeRequest(
+        PATH,
+        GET_METHOD,
+        BODY,
+        HEADERS,
+        TIMEOUT,
+        metricType,
+        requestConfig
+      ).catch((err) => {
+        console.error(err);
+      });
+
+      expect(authSpy).toHaveBeenCalledWith({
+        path: PATH,
+        method: GET_METHOD,
+        body: BODY,
+        headers: HEADERS,
+        ...requestConfig,
+      });
       expect(sendSpy).toHaveBeenCalled();
       expect(result.err).toBeUndefined();
       expect(result.response.status).toEqual(SUCCESS_CODE);


### PR DESCRIPTION
Previously if we wrote an item to edgekv like `\"kp_test_value1\"`, when reading it the API would return the item with the quotes but our CLI would strip out the extra quotes.

This is due to an axios bug that seems to improperly parse strings with quotes in them. As a fix we can just [override](https://github.com/akamai/cli-edgeworkers/compare/develop...fix/EW-13257?expand=1#diff-fef3728152f5e206dfc82e09e2bd8988704edf58f467e42cbfedfccda535fa1fR58) the parser with our own implementation when reading edgekv items.