### PR TITLE
EW-7436: Improve help output when using a narrow window

### DIFF
--- a/src/edgekv/ekv-cli-main.ts
+++ b/src/edgekv/ekv-cli-main.ts
@@ -62,9 +62,20 @@ program
     cliUtils.logAndExit(0, copywrite);
   });
 
+  const helper = program.createHelp();
+  program.configureHelp({
+    optionDescription: () => '',
+    optionTerm: (cmd) => 
+      helper.optionTerm(cmd) + '\n\t' + helper.optionDescription(cmd),
+  
+    subcommandDescription: () => '' ,
+    subcommandTerm: (cmd) => 
+      helper.subcommandTerm(cmd) + '\n\t' + helper.subcommandDescription(cmd),
+  });
+
 program
   .command('help [command]')
-  .description('Displays help information for the given command.')
+  .description('Displays help information for the given command')
   .action(function (arg) {
     if (!arg) {
       program.outputHelp();
@@ -86,7 +97,7 @@ program
 
 program
   .command('initialize')
-  .description('Initialize edgeKV for the first time')
+  .description('Initialize EdgeKV for the first time')
   .alias('init')
   .action(async function () {
     try {
@@ -198,7 +209,7 @@ const list = program
   .command('list')
   .alias('l')
   .description(
-    'List all the namespaces or the data groups for a given namespace in an Akamai environment. Use list -h to see available options'
+    'List all the namespaces or the data groups for a given namespace in an Akamai environment'
   );
 
 list
@@ -219,7 +230,7 @@ list
     '--desc, --descending',
     'Set the sort direction to descending order'
   )
-  .description('List all the namespaces')
+  .description('List all namespaces')
   .action(async function (environment, options) {
     let sortDirection: cliUtils.sortDirections, orderBy: string;
 
@@ -296,7 +307,7 @@ list
     '--sandboxId <sandboxId>',
     '`sandbox-id` to use for the data operation. You can use the `akamai sandbox list` CLI command to view a list of available sandboxes.'
   )
-  .description('List items with in a group')
+  .description('List items within a group')
   .action(async function (environment, namespace, groupId, options) {
     try {
       await kvCliHandler.listItemsFromGroup(
@@ -317,7 +328,7 @@ list
 list
   .command('tokens')
   .option('--include-expired', 'Returns expired tokens in the response')
-  .description('List all tokens for which the user has permission to download.')
+  .description('List all tokens for which the user has permission to download')
   .action(async function (options) {
     try {
       await kvCliHandler.listTokens(options.includeExpired);
@@ -339,7 +350,7 @@ list
     '-incewg, --include_ew_groups',
     'Returns expired tokens in the response'
   )
-  .description('List all tokens for which the user has permission to download.')
+  .description('List group identifiers created when writing items to a namespace')
   .action(async function (options) {
     try {
       await kvCliHandler.listAuthGroups(options);
@@ -452,7 +463,8 @@ create
     cliUtils.logAndExit(0, copywrite);
   });
 
-const revoke = program.command('revoke');
+const revoke = program.command('revoke')
+  .description('Revoke an EdgeKV token');
 revoke
   .command('token <tokenName>')
   .description('Revoke an EdgeKV token')
@@ -467,7 +479,8 @@ revoke
     cliUtils.logAndExit(0, copywrite);
   });
 
-const modify = program.command('modify');
+const modify = program.command('modify')
+  .description('Modify EdgeKV namespace or permission group');
 modify
   .command('ns <environment> <namespace>')
   .requiredOption(
@@ -529,12 +542,10 @@ download
 
 const show = program
   .command('show')
-  .description(
-    'Check the initialization status of the EdgeKV or Retrieve an EdgeKV namespace. Use show -h to see available options'
-  );
+  .description('Check the initialization status of the EdgeKV or Retrieve an EdgeKV namespace');
 show
   .command('status')
-  .description('Check the initialization status of the edgeKV')
+  .description('Check the EdgeKV initialization status')
   .action(async function () {
     try {
       await kvCliHandler.getInitializationStatus();

--- a/src/edgeworkers/ew-cli-main.ts
+++ b/src/edgeworkers/ew-cli-main.ts
@@ -55,9 +55,20 @@ program
     cliUtils.logAndExit(0, copywrite);
   });
 
+const helper = program.createHelp();
+program.configureHelp({
+  optionDescription: () => '',
+  optionTerm: (cmd) => 
+    helper.optionTerm(cmd) + '\n\t' + helper.optionDescription(cmd),
+
+  subcommandDescription: () => '' ,
+  subcommandTerm: (cmd) => 
+    helper.subcommandTerm(cmd) + '\n\t' + helper.subcommandDescription(cmd),
+});
+
 program
   .command('help [command]')
-  .description('Displays help information for the given command.')
+  .description('Displays help information for the given command')
   .action(function (arg) {
     if (!arg) {
       program.outputHelp();
@@ -81,7 +92,7 @@ program
 
 program
   .command('list-groups [group-identifier]')
-  .description('Customer Developer can find their EdgeWorkers access level per Luna Access Control Group.')
+  .description('View a list of groups and the associated permission capabilities')
   .alias('lg')
   .action(async function (groupId) {
     try {
@@ -96,7 +107,7 @@ program
 
 program
   .command('list-ids [edgeworker-identifier]')
-  .description('List EdgeWorker ids currently registered.')
+  .description('List EdgeWorker ids currently registered')
   .alias('li')
   .option('--groupId <groupId>', 'Filter EdgeWorker Id list by Permission Group')
   .option('-restier, --resourceTierId <resourceTierId>', 'Filter EdgeWorkers by resource tiers')
@@ -113,9 +124,9 @@ program
 
 program
   .command('register <group-identifier> <edgeworker-name>')
-  .description('Register a new EdgeWorker id to reference in Property Manager behavior.')
+  .description('Register a new EdgeWorker Id to reference in Property Manager behavior')
   .alias('create-id')
-  .option('-restier, --resourceTierId <resourceTierId>', 'New resource Tier id to associate with EdgeWorker')
+  .option('-restier, --resourceTierId <resourceTierId>', 'New resource Tier Id to associate with EdgeWorker')
   .action(async function (groupId, name, options) {
     try {
       // for automation resource tier id will be provided , hence no need for prompts
@@ -124,7 +135,7 @@ program
       // get contract list and get resource tier info
       resourceTierId = await cliHandler.getResourceTierInfo();
       if (resourceTierId == undefined) {
-        cliUtils.logAndExit(1, 'ERROR: Please select a valid resource tier id.');
+        cliUtils.logAndExit(1, 'ERROR: Please select a valid resource tier Id.');
       }
       }
       // create edgeworker for the grpid, res tier and ew name
@@ -139,7 +150,7 @@ program
 
 program
   .command('list-contracts')
-  .description('Allows customer to view the list of contracts associated with their account')
+  .description('View the list of contracts associated with an account')
   .alias('li-contracts')
   .action(async function () {
     try {
@@ -154,7 +165,7 @@ program
 
 program
   .command('list-properties <edgeworkerId>')
-  .description('Allows customer to view the list of properties associated with the EdgeWorker Id')
+  .description('View the list of properties associated with an EdgeWorker Id')
   .option('--activeOnly', 'Return only active properties')
   .alias('lp')
   .action(async function (edgeWorkerId, options) {
@@ -170,7 +181,7 @@ program
 
 program
   .command('list-restiers')
-  .description('Allows customer to view the list of resource tiers available for the specified contract')
+  .description('View the list of resource tiers available for a specified contract')
   .option('--contractId <contractId>', 'Contract id for the resource tiers')
   .alias('li-restiers')
   .action(async function (options) {
@@ -186,7 +197,7 @@ program
 
 program
   .command('list-limits')
-  .description('List the various limits EdgeWorkers imposes on the number of activations, EdgeWorkers IDs, and versions you can deploy.')
+  .description('List the various limits EdgeWorkers imposes on the number of activations, EdgeWorkers IDs, and versions you can deploy')
   .alias('li-limits')
   .action(async function () {
     try {
@@ -201,7 +212,7 @@ program
 
 program
   .command('show-restier <edgeworkerId>')
-  .description('Allows customer to view the resource tier associated with the EdgeWorker Id')
+  .description('View the resource tier associated with an EdgeWorker Id')
   .action(async function (edgeworkerId) {
     try {
       await cliHandler.getResourceTierForEwid(edgeworkerId);
@@ -215,8 +226,8 @@ program
 
 program
   .command('update-id <edgeworker-identifier> <group-identifier> <edgeworker-name>')
-  .description('Allows Customer Developer to update an existing EdgeWorker Identifier\'s Luna ACG or Name attributes.')
-  .option('-restier, --resourceTierId <resourceTierId>', 'New resource Tier id to associate with EdgeWorker')
+  .description('Update an existing EdgeWorker Identifier\'s Luna ACG or Name attributes')
+  .option('-restier, --resourceTierId <resourceTierId>', 'New resource Tier Id to associate with EdgeWorker')
   .alias('ui')
   .action(async function (ewId, groupId, name, options) {
     try {
@@ -231,7 +242,7 @@ program
 
 program
   .command('delete-id <edgeworker-identifier>')
-  .description('Permanently delete an existing EdgeWorker Id.')
+  .description('Permanently delete an existing EdgeWorker Id')
   .option('--noPrompt', 'Skip the deletion confirmation prompt')
   .action(async function (ewId, options) {
     try {
@@ -246,7 +257,7 @@ program
 
 program
   .command('list-versions <edgeworker-identifier> [version-identifier]')
-  .description('List Version information of a given EdgeWorker Id.')
+  .description('List Version information of a given EdgeWorker Id')
   .alias('lv')
   .action(async function (ewId, versionId) {
     try {
@@ -261,7 +272,7 @@ program
 
 program
   .command('upload <edgeworker-identifier>')
-  .description('Creates a new version of a given EdgeWorker Id which includes the code bundle.')
+  .description('Creates a new version of a given EdgeWorker Id which includes the code bundle')
   .alias('create-version')
   .option('--bundle <bundlePath>', 'Path to bundle file in tgz format')
   .option('--codeDir <workingDirectory>', 'Working directory that includes main.js and bundle.json files')
@@ -283,7 +294,7 @@ program
 
 program
   .command('delete-version <edgeworker-identifier> <version-identifier>')
-  .description('Permanently delete an existing version of a given EdgeWorker Id.')
+  .description('Permanently delete an existing version of a given EdgeWorker Id')
   .option('--noPrompt', 'Skip the deletion confirmation prompt')
   .action(async function (ewId, versionId, options) {
     try {
@@ -298,7 +309,7 @@ program
 
 program
   .command('download <edgeworker-identifier> <version-identifier>')
-  .description('Download the code bundle of an EdgeWorker version.')
+  .description('Download the code bundle of an EdgeWorker version')
   .alias('download-version')
   .option('--downloadPath <downloadPath>', 'Path to store downloaded bundle file; defaults to CLI home directory if not provided')
   .action(async function (ewId, versionId, options) {
@@ -314,7 +325,7 @@ program
 
 program
   .command('status <edgeworker-identifier>')
-  .description('List Activation status of a given EdgeWorker Id.')
+  .description('List Activation status of a given EdgeWorker Id')
   .alias('list-activations')
   .option('--versionId <versionId>', 'Version Identifier')
   .option('--activationId <activationId>', 'Activation Identifier')
@@ -354,7 +365,7 @@ program
 
 program
   .command('clone <edgeworker-identifier> <resourceTierId>')
-  .description('Clone the given EdgeWorker Id on an akamai network')
+  .description('Clone the given EdgeWorker Id on an Akamai network')
   .option('--ewName <name>', 'Name of the EdgeWorker')
   .option('--groupId <groupId>', 'GroupId in which EdgeWorker will be cloned')
   .action(async function (ewId, resourceTierId, options) {
@@ -389,7 +400,7 @@ program
 
 program
   .command('validate <bundlePath>')
-  .description('Validates a code bundle version without uploading the code bundle.')
+  .description('Validates a code bundle version without uploading the code bundle')
   .alias('vv')
   .action(async function (bundlePath) {
 
@@ -405,7 +416,7 @@ program
 
 program
   .command('generate-secret')
-  .description('Generates a random secret key that can be used in the variable PMUSER_EW_DEBUG_KEY in their property.')
+  .description('Generates a random secret key that can be used in the variable PMUSER_EW_DEBUG_KEY in their property')
   .alias('secret')
   .action(async function () {
     const length = 32;
@@ -421,7 +432,7 @@ program
 
 program
   .command('create-auth-token <hostName>')
-  .description('Generates an authentication token that can be used to get detailed EdgeWorker debug response headers.')
+  .description('Generates an authentication token that can be used to get detailed EdgeWorker debug response headers')
   .alias('auth')
   .option('--network <network>','The Akamai environment on which to create this token, either “staging” or “production”')
   .option('--acl <aclPath>', 'The path prefix of the response pages which require debugging; this value is used to restrict for which pages the token is valid. \
@@ -476,7 +487,7 @@ get
   .option('--ev, --eventHandlers <eventHandlers>', 'Comma-separated string to filter EdgeWorkers by the event that triggers them. Values: onClientRequest, onOriginRequest, onOriginResponse, onClientResponse, responseProvider.')
   .action(async function (reportId: number, edgeworkerId: string, options) {
     if (!reportId){
-      cliUtils.logAndExit(1, 'ERROR: Please specify a reportId. To obtain the available report ID run "akamai edgeworkers get reports".');
+      cliUtils.logAndExit(1, 'ERROR: Please specify a reportId. To obtain the available report Id run "akamai edgeworkers get reports".');
     }
     const {startDate, endDate, status, eventHandlers} = options;
 

--- a/src/edgeworkers/ew-cli-main.ts
+++ b/src/edgeworkers/ew-cli-main.ts
@@ -109,7 +109,7 @@ program
   .command('list-ids [edgeworker-identifier]')
   .description('List EdgeWorker ids currently registered')
   .alias('li')
-  .option('--groupId <groupId>', 'Filter EdgeWorker Id list by Permission Group')
+  .option('--groupId <groupId>', 'Filter EdgeWorker ID list by Permission Group')
   .option('-restier, --resourceTierId <resourceTierId>', 'Filter EdgeWorkers by resource tiers')
   .action(async function (ewId, options) {
     try {
@@ -124,9 +124,9 @@ program
 
 program
   .command('register <group-identifier> <edgeworker-name>')
-  .description('Register a new EdgeWorker Id to reference in Property Manager behavior')
+  .description('Register a new EdgeWorker ID to reference in Property Manager behavior')
   .alias('create-id')
-  .option('-restier, --resourceTierId <resourceTierId>', 'New resource Tier Id to associate with EdgeWorker')
+  .option('-restier, --resourceTierId <resourceTierId>', 'New resource Tier ID to associate with EdgeWorker')
   .action(async function (groupId, name, options) {
     try {
       // for automation resource tier id will be provided , hence no need for prompts
@@ -135,7 +135,7 @@ program
       // get contract list and get resource tier info
       resourceTierId = await cliHandler.getResourceTierInfo();
       if (resourceTierId == undefined) {
-        cliUtils.logAndExit(1, 'ERROR: Please select a valid resource tier Id.');
+        cliUtils.logAndExit(1, 'ERROR: Please select a valid resource tier ID.');
       }
       }
       // create edgeworker for the grpid, res tier and ew name
@@ -165,7 +165,7 @@ program
 
 program
   .command('list-properties <edgeworkerId>')
-  .description('View the list of properties associated with an EdgeWorker Id')
+  .description('View the list of properties associated with an EdgeWorker ID')
   .option('--activeOnly', 'Return only active properties')
   .alias('lp')
   .action(async function (edgeWorkerId, options) {
@@ -182,7 +182,7 @@ program
 program
   .command('list-restiers')
   .description('View the list of resource tiers available for a specified contract')
-  .option('--contractId <contractId>', 'Contract id for the resource tiers')
+  .option('--contractId <contractId>', 'Contract ID for the resource tiers')
   .alias('li-restiers')
   .action(async function (options) {
     try {
@@ -212,7 +212,7 @@ program
 
 program
   .command('show-restier <edgeworkerId>')
-  .description('View the resource tier associated with an EdgeWorker Id')
+  .description('View the resource tier associated with an EdgeWorker ID')
   .action(async function (edgeworkerId) {
     try {
       await cliHandler.getResourceTierForEwid(edgeworkerId);
@@ -227,7 +227,7 @@ program
 program
   .command('update-id <edgeworker-identifier> <group-identifier> <edgeworker-name>')
   .description('Update an existing EdgeWorker Identifier\'s Luna ACG or Name attributes')
-  .option('-restier, --resourceTierId <resourceTierId>', 'New resource Tier Id to associate with EdgeWorker')
+  .option('-restier, --resourceTierId <resourceTierId>', 'New resource Tier ID to associate with EdgeWorker')
   .alias('ui')
   .action(async function (ewId, groupId, name, options) {
     try {
@@ -242,7 +242,7 @@ program
 
 program
   .command('delete-id <edgeworker-identifier>')
-  .description('Permanently delete an existing EdgeWorker Id')
+  .description('Permanently delete an existing EdgeWorker ID')
   .option('--noPrompt', 'Skip the deletion confirmation prompt')
   .action(async function (ewId, options) {
     try {
@@ -257,7 +257,7 @@ program
 
 program
   .command('list-versions <edgeworker-identifier> [version-identifier]')
-  .description('List Version information of a given EdgeWorker Id')
+  .description('List Version information of a given EdgeWorker ID')
   .alias('lv')
   .action(async function (ewId, versionId) {
     try {
@@ -272,7 +272,7 @@ program
 
 program
   .command('upload <edgeworker-identifier>')
-  .description('Creates a new version of a given EdgeWorker Id which includes the code bundle')
+  .description('Creates a new version of a given EdgeWorker ID which includes the code bundle')
   .alias('create-version')
   .option('--bundle <bundlePath>', 'Path to bundle file in tgz format')
   .option('--codeDir <workingDirectory>', 'Working directory that includes main.js and bundle.json files')
@@ -294,7 +294,7 @@ program
 
 program
   .command('delete-version <edgeworker-identifier> <version-identifier>')
-  .description('Permanently delete an existing version of a given EdgeWorker Id')
+  .description('Permanently delete an existing version of a given EdgeWorker ID')
   .option('--noPrompt', 'Skip the deletion confirmation prompt')
   .action(async function (ewId, versionId, options) {
     try {
@@ -325,7 +325,7 @@ program
 
 program
   .command('status <edgeworker-identifier>')
-  .description('List Activation status of a given EdgeWorker Id')
+  .description('List Activation status of a given EdgeWorker ID')
   .alias('list-activations')
   .option('--versionId <versionId>', 'Version Identifier')
   .option('--activationId <activationId>', 'Activation Identifier')
@@ -346,7 +346,7 @@ program
 
 program
   .command('activate <edgeworker-identifier> <network> <version-identifier>')
-  .description('Activate a Version for a given EdgeWorker Id on an Akamai Network')
+  .description('Activate a Version for a given EdgeWorker ID on an Akamai Network')
   .alias('av')
   .action(async function (ewId, network, versionId) {
 
@@ -365,7 +365,7 @@ program
 
 program
   .command('clone <edgeworker-identifier> <resourceTierId>')
-  .description('Clone the given EdgeWorker Id on an Akamai network')
+  .description('Clone the given EdgeWorker ID on an Akamai network')
   .option('--ewName <name>', 'Name of the EdgeWorker')
   .option('--groupId <groupId>', 'GroupId in which EdgeWorker will be cloned')
   .action(async function (ewId, resourceTierId, options) {
@@ -381,7 +381,7 @@ program
 
 program
   .command('deactivate <edgeworker-identifier> <network> <version-identifier>')
-  .description('De-activate a version for a given EdgeWorker Id on an Akamai Network')
+  .description('De-activate a version for a given EdgeWorker ID on an Akamai Network')
   .alias('deact')
   .action(async function (ewId, network, versionId) {
     
@@ -487,7 +487,7 @@ get
   .option('--ev, --eventHandlers <eventHandlers>', 'Comma-separated string to filter EdgeWorkers by the event that triggers them. Values: onClientRequest, onOriginRequest, onOriginResponse, onClientResponse, responseProvider.')
   .action(async function (reportId: number, edgeworkerId: string, options) {
     if (!reportId){
-      cliUtils.logAndExit(1, 'ERROR: Please specify a reportId. To obtain the available report Id run "akamai edgeworkers get reports".');
+      cliUtils.logAndExit(1, 'ERROR: Please specify a reportId. To obtain the available report ID run "akamai edgeworkers get reports".');
     }
     const {startDate, endDate, status, eventHandlers} = options;
 


### PR DESCRIPTION
The command descriptions are now shown in a tabbed new line under the command usage. This makes the help output taller but improves the readability when using a narrow terminal window. This PR also includes some small improvements to some of the command descriptions.

New output:
![image](https://user-images.githubusercontent.com/33794710/206286282-020f0912-1bcb-46b5-9a55-2228d12d0eb5.png)

Narrow window example:
![image](https://user-images.githubusercontent.com/33794710/206286513-68d2a815-7fb7-4f50-8ddf-eae24609176a.png)

Old behaviour with narrow window:
![image](https://user-images.githubusercontent.com/33794710/206286825-00895d1d-137c-4bed-8355-5ea185a9078e.png)
