### PR TITLE
pendo track event header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akamai-edgeworkers-cli",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A tool that makes it easier to manage Akamai EdgeWorkers code bundles and EdgeKV databases. Call the EdgeWorkers and EdgeKV API from the command line.",
   "repository": "https://github.com/akamai/cli-edgeworkers",
   "scripts": {


### PR DESCRIPTION
do-not merge this until develop is being tested by QA team. this helps us to differentiate working of pendo event from master and develop