### PR TITLE
Fix CLI errors when the ew-config file path not found

### DIFF
--- a/cli.json
+++ b/cli.json
@@ -5,13 +5,13 @@
   "commands": [
     {
       "name": "edgeworkers",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "aliases": ["ew", "edgeworkers"],
       "description": "Manage Akamai EdgeWorkers code bundles."
     },
     {
       "name": "edgekv",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "aliases": ["ekv", "edgekv"],
       "description": "Manage Akamai EdgeKV database."
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akamai-edgeworkers-cli",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "akamai-edgeworkers-cli",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akamai-edgeworkers-cli",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "A tool that makes it easier to manage Akamai EdgeWorkers code bundles and EdgeKV databases. Call the EdgeWorkers and EdgeKV API from the command line.",
   "repository": "https://github.com/akamai/cli-edgeworkers",
   "scripts": {

--- a/src/utils/config-utils.ts
+++ b/src/utils/config-utils.ts
@@ -21,6 +21,7 @@ export const Operations = {
 export class Config {
   path: string;
   section: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   config: any;
 
   constructor(path: string, section: string) {
@@ -28,10 +29,16 @@ export class Config {
     this.section = section;
 
     // create a config file if it doesn't exist
-    if (!fs.existsSync(this.path)) {
-      fs.writeFileSync(this.path, '');
+    try {
+      if (!fs.existsSync(this.path)) {
+        fs.writeFileSync(this.path, '');
+      }
+      this.config = ini.parse(fs.readFileSync(this.path, 'utf8'));
+    } catch (e) {
+      // When fail to write or read the config file, treat it as an empty config file
+      console.error(`File path not found: ${this.path}`);
+      this.config = {};
     }
-    this.config = ini.parse(fs.readFileSync(this.path, 'utf8'));
 
     // initialize the section if not exist
     if (!(this.section in this.config)) {
@@ -39,6 +46,7 @@ export class Config {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   save(context: any=null) {
     try {
       if (context) {


### PR DESCRIPTION
### Major Changes
- Catch and ignore the error when the file path of `ew-config` does not exit

### Result
Before changes
![image](https://user-images.githubusercontent.com/108763111/231520025-af909dc1-b890-454f-8ac8-9d4a874b69e8.png)

After changes
![image](https://user-images.githubusercontent.com/108763111/231518705-ad7fe13f-55dc-4db0-a81f-6b8d042413ea.png)

