### PR TITLE
fix typo: l to L, in EdgeKV namespace creation CLI

### DIFF
--- a/docs/edgekv_cli.md
+++ b/docs/edgekv_cli.md
@@ -190,7 +190,7 @@ Usage: `akamai edgekv create ns <environment> <nameSpace>`
 | -h, --help  | optional | Display information on how to use this EdgeKV command. |
 | --retention | Required | Retention period of the namespace in days. |
 | --groupId | Required | Group identifier. Set it to 0 to allow all groups in your account to access the namespace. If you want to restrict the namespace to a specific group, enter the group id. This value MUST be the same for both the staging and production instances of a namespace. |
-| --geolocation | optional | Specifies the persistent storage location for data when creating a namespace on the production network. This can help optimize performance by storing data where most or all of your users are located. The value defaults to `US` on the `STAGING` and `PRODUCTION` networks. For more information refer to the [EdgeKV Documenation](https://techdocs.akamai.com/edgekv/docs/edgekv-data-model#namespace).|
+| --geoLocation | optional | Specifies the persistent storage location for data when creating a namespace on the production network. This can help optimize performance by storing data where most or all of your users are located. The value defaults to `US` on the `STAGING` and `PRODUCTION` networks. For more information refer to the [EdgeKV Documenation](https://techdocs.akamai.com/edgekv/docs/edgekv-data-model#namespace).|
 
 | Argument | Existence | Description |
 | - | - | - |


### PR DESCRIPTION
The `--geolocation` command option should be corrected to `--geoLocation`.

We see following message when we use `--geolocation`.
```
error: unknown option '--geolocation'
(Did you mean --geoLocation?)
```